### PR TITLE
make base.install work on a more bare system

### DIFF
--- a/braid/base.py
+++ b/braid/base.py
@@ -22,6 +22,11 @@ def bootstrap():
     # Each service specific system user shall be added to the 'service' group
     sudo('/usr/sbin/groupadd -f --system service')
 
+    # pypy is installed with a tarball downloaded with wget.
+    package.install(['wget'])
+    # libssl-dev is needed for installing pyOpenSSL for PyPy.
+    package.install(['libssl-dev'])
+
     package.install(['python2.7', 'python2.7-dev'])
     # gcc is needed for 'pip install'
     package.install(['gcc', 'python-pip'])

--- a/braid/pypy.py
+++ b/braid/pypy.py
@@ -9,7 +9,7 @@ pypyURLs = {
     'x86_64': 'https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-linux64.tar.bz2',
     'x86': 'https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-linux.tar.bz2',
     }
-pypyDir = '/opt/pypy-2.0'
+pypyDir = '/opt/pypy-2.0.2'
 
 setuptoolsURL = 'http://peak.telecommunity.com/dist/ez_setup.py'
 pipURL = 'https://raw.github.com/pypa/pip/master/contrib/get-pip.py'


### PR DESCRIPTION
Installs wget and libssl-dev, and fixes the pypy directory name.

I'm least certain about the pypyDir change; how will this interact with already working systems?
