### PR TITLE
Upgrade to pypy 2.2.1

### DIFF
--- a/braid/pypy.py
+++ b/braid/pypy.py
@@ -6,12 +6,12 @@ from braid import info
 from braid.utils import fails
 
 pypyURLs = {
-    'x86_64': 'https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux64.tar.bz2',
-    'x86': 'https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux.tar.bz2',
+    'x86_64': 'https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux64.tar.bz2',
+    'x86': 'https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux.tar.bz2',
     }
 pypyDirs = {
-    'x86_64': '/opt/pypy-2.2-linux64',
-    'x86': '/opt/pypy-2.2-linux',
+    'x86_64': '/opt/pypy-2.2.1-linux64',
+    'x86': '/opt/pypy-2.2.1-linux',
     }
 
 setuptoolsURL = 'https://bitbucket.org/pypa/setuptools/raw/default/ez_setup.py'


### PR DESCRIPTION
Upgrade to pypy-2.2.1 to fix https download errors.

This change (along with #58) allows me to run fab --user root --hosts 127.0.0.1 base.bootstrap against a new Ubuntu 12.10 server.

Fixes #55