### PR TITLE
[WIP] Add basic vagrant file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,16 @@ Things that want to root want to be run with `sudo`, and files `put` with `use_s
 When dealing with things that want to be run as other users, `run` should be
 used, and a ssh connection as that user (with `settings(user='user')` or the like.
 `braid.base.sshConfig` sets things up so anybody with root keys can log-in as any user in the `service` group.
+
+
+Vagrant
+=======
+
+There is `Vagrantfile` provided with braid, that will setup a staging sever.
+It uses the address `172.16.255.140`, and there is a brain config named `vagrant` that connects to it by default.
+
+```shell
+vagrant up
+ssh-add ~/.vagrant.d/insecure_private_key
+fab config.vagrant base.bootstrap
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/precise64"
+  config.vm.network :private_network, :ip => "172.16.255.140"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,4 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/precise64"
   config.vm.network :private_network, :ip => "172.16.255.140"
   config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provision "shell",
+    inline: "cp ~vagrant/.ssh/authorized_keys /root/.ssh"
 end

--- a/braid/settings.py
+++ b/braid/settings.py
@@ -4,6 +4,8 @@ Default configuration settings.
 
 dornkirk = 'dornkirk.twistedmatrix.com'
 
+vagrant_address = '172.16.255.140'
+
 ENVIRONMENTS = {
     'production': {
         'hosts': [dornkirk],
@@ -13,4 +15,12 @@ ENVIRONMENTS = {
         'user': 'root',
         'installPrivateData': True,
     },
+    'vagrant': {
+        'hosts': [vagrant_address],
+        'roledefs': {
+            'nameserver': [vagrant_address],
+        },
+        'user': 'vagrant',
+        'installPrivateData': False,
+    }
 }

--- a/braid/settings.py
+++ b/braid/settings.py
@@ -20,7 +20,7 @@ ENVIRONMENTS = {
         'roledefs': {
             'nameserver': [vagrant_address],
         },
-        'user': 'vagrant',
+        'user': 'root',
         'installPrivateData': False,
     }
 }


### PR DESCRIPTION
Fixes #75.

This appears to work to run `base.bootstrap` and `t-names.install`. But I haven't checked the results thereof.