### PR TITLE
Add vagrant configuration to help with infrastructre development / testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /braidrc.local/*.py
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -129,3 +129,16 @@ Things that want to root want to be run with `sudo`, and files `put` with `use_s
 When dealing with things that want to be run as other users, `run` should be
 used, and a ssh connection as that user (with `settings(user='user')` or the like.
 `braid.base.sshConfig` sets things up so anybody with root keys can log-in as any user in the `service` group.
+
+
+Vagrant
+=======
+
+There is `Vagrantfile` provided with braid, that will setup a staging sever.
+It uses the address `172.16.255.140`, and there is a brain config named `vagrant` that connects to it by default.
+
+```shell
+vagrant up
+ssh-add ~/.vagrant.d/insecure_private_key
+fab config.vagrant base.bootstrap
+```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Vagrant
 =======
 
 There is `Vagrantfile` provided with braid, that will setup a staging sever.
-It uses the address `172.16.255.140`, and there is a brain config named `vagrant` that connects to it by default.
+It uses the address `172.16.255.140`, and there is a braid config named `vagrant` that connects to it by default.
 
 ```shell
 # Get the required base OS image if you don't have it yet.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,13 @@ There is `Vagrantfile` provided with braid, that will setup a staging sever.
 It uses the address `172.16.255.140`, and there is a brain config named `vagrant` that connects to it by default.
 
 ```shell
+# Get the required base OS image if you don't have it yet.
+vagrant box add precise64 http://files.vagrantup.com/precise64.box
+# Start the VM
 vagrant up
+# With ssh-aget add private key used by Vagrant
 ssh-add ~/.vagrant.d/insecure_private_key
-fab config.vagrant base.bootstrap
+fab config.vagrant COMMAND
+# Or without ssh-agent
+fab -i ~/.vagrant.d/insecure_private_key config.vagrant COMMAND
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,8 +15,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/precise64"
   config.vm.network :private_network, :ip => "172.16.255.140"
+  # Default folder synchronization is disables as the host is managed using
+  # fabric/braid.
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
+  # The only vagrant provisioning is to enable SSH access for root account.
+  # After that provisioning is done using fabric/braid.
   config.vm.provision "shell",
     inline: $root_ssh_authorized_keys, privileged: true
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/precise64"
+  config.vm.network :private_network, :ip => "172.16.255.140"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,13 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+# Provision root account with the insecure Vagrant ssh key.
+$root_ssh_authorized_keys = <<ENDMARKER
+mkdir /root/.ssh
+chmod 700 /root/.ssh
+cp ~vagrant/.ssh/authorized_keys /root/.ssh
+ENDMARKER
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "ubuntu/precise64"
@@ -11,5 +18,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provision "shell",
-    inline: "cp ~vagrant/.ssh/authorized_keys /root/.ssh"
+    inline: $root_ssh_authorized_keys, privileged: true
+
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,4 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/precise64"
   config.vm.network :private_network, :ip => "172.16.255.140"
   config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provision "shell",
+    inline: "cp ~vagrant/.ssh/authorized_keys /root/.ssh"
 end

--- a/braid/settings.py
+++ b/braid/settings.py
@@ -4,6 +4,8 @@ Default configuration settings.
 
 dornkirk = 'dornkirk.twistedmatrix.com'
 
+vagrant_address = '172.16.255.140'
+
 ENVIRONMENTS = {
     'production': {
         'hosts': [dornkirk],
@@ -13,4 +15,12 @@ ENVIRONMENTS = {
         'user': 'root',
         'installPrivateData': True,
     },
+    'vagrant': {
+        'hosts': [vagrant_address],
+        'roledefs': {
+            'nameserver': [vagrant_address],
+        },
+        'user': 'vagrant',
+        'installPrivateData': False,
+    }
 }

--- a/braid/settings.py
+++ b/braid/settings.py
@@ -20,7 +20,7 @@ ENVIRONMENTS = {
         'roledefs': {
             'nameserver': [vagrant_address],
         },
-        'user': 'vagrant',
+        'user': 'root',
         'installPrivateData': False,
     }
 }


### PR DESCRIPTION
Problem
======

As there is no easy way to reproduce twisted infa hosts on your system development and testing of new features is a PITA

A Vagrant VM could help in create a stating server to be used for dev and testing.

Changes
=======

This builds on top #76

I have fixed the provisioning of root account and updated the docs.

How to test
=========

Install vagrant and follow the README steps.

Check  that docs make sense.

Check that you can start the vagrant VM and run a fab command.

As a test you can run the `base.bootstrap` command.
