### PR TITLE
Move t-names submodule into a simple folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "services/t-names"]
-	path = services/t-names
-	url = https://github.com/twisted-infra/t-names
 [submodule "services/diffresource"]
 	path = services/diffresource
 	url = https://github.com/twisted-infra/diffresource

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ deploy itself on a given machine.
 Currently Supported Services
 ============================
 
-- [t-names](https://github.com/twisted-infra/t-names)
+- t-names
 - [t-web](https://github.com/twisted-infra/t-web)
 - buildbot
 - [diffresource](https://github.com/twisted-infra/diffresource)

--- a/services/t-names/README
+++ b/services/t-names/README
@@ -1,0 +1,23 @@
+This is the configuration for twistedmatrix.com's DNS server using twisted.names.
+
+It is adminstered using braid[1]. It is installed in `/srv/t-names` as user t-names.
+It uses the following directories
+
+~/config - This repository.
+~/config/zones - DNS zone info
+~/bin - commands to start and stop the server
+~/log - log files
+~/run - pid files
+
+The DNS info has the ip address of all hosts in `hosts.py`, as well as some utility
+functions. The remaning files are zone definitions using those utilities and hosts.
+
+The following fabric commands are available:
+
+install - Create user and install configuration.
+update - Updates the configuration and restarts the server.
+start - Start server.
+stop - Stop server.
+restart - Restart the server.
+
+[1] https://github.com/twisted-infra/braid

--- a/services/t-names/crontab
+++ b/services/t-names/crontab
@@ -1,0 +1,1 @@
+@reboot ~/bin/start

--- a/services/t-names/fabfile.py
+++ b/services/t-names/fabfile.py
@@ -1,8 +1,9 @@
 """
 Support for DNS service installation and management.
 """
+import os
 
-from fabric.api import run, settings
+from fabric.api import execute, put, run, settings
 
 from braid import authbind, git, cron
 from braid.twisted import service
@@ -25,7 +26,7 @@ class TwistedNames(service.Service):
 
         with settings(user=self.serviceUser):
             run('/bin/ln -nsf {}/start {}/start'.format(self.configDir, self.binDir))
-            self.update()
+            execute(self.update)
             cron.install(self.serviceUser, '{}/crontab'.format(self.configDir))
 
 
@@ -34,7 +35,10 @@ class TwistedNames(service.Service):
         Update config.
         """
         with settings(user=self.serviceUser):
-            git.branch('https://github.com/twisted-infra/t-names', self.configDir)
+            run('mkdir -p ' + self.configDir)
+            put(
+                os.path.dirname(__file__) + '/*', self.configDir,
+                mirror_local_mode=True)
 
     def task_update(self):
         """

--- a/services/t-names/fabfile.py
+++ b/services/t-names/fabfile.py
@@ -1,0 +1,48 @@
+"""
+Support for DNS service installation and management.
+"""
+
+from fabric.api import run, settings
+
+from braid import authbind, git, cron
+from braid.twisted import service
+
+from braid import config
+_hush_pyflakes = [ config ]
+
+
+class TwistedNames(service.Service):
+
+    def task_install(self):
+        """
+        Install t-names, a Twisted Names based DNS server.
+        """
+        # Bootstrap a new service environment
+        self.bootstrap()
+
+        # Setup authbind
+        authbind.allow(self.serviceUser, 53)
+
+        with settings(user=self.serviceUser):
+            run('/bin/ln -nsf {}/start {}/start'.format(self.configDir, self.binDir))
+            self.update()
+            cron.install(self.serviceUser, '{}/crontab'.format(self.configDir))
+
+
+    def update(self):
+        """
+        Update config.
+        """
+        with settings(user=self.serviceUser):
+            git.branch('https://github.com/twisted-infra/t-names', self.configDir)
+
+    def task_update(self):
+        """
+        Update config and restart.
+        """
+        self.update()
+        self.task_restart()
+
+
+
+globals().update(TwistedNames('t-names').getTasks(role='nameserver'))

--- a/services/t-names/start
+++ b/services/t-names/start
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+Z=~/config/zones
+export PYTHONPATH=$PYTHONPATH:$Z
+
+authbind --deep ~pypy/bin/twistd \
+    --logfile ~/log/twistd.log \
+    --pidfile ~/run/twistd.pid \
+    dns \
+    --pyzone $Z/twistedmatrix.com \
+    --pyzone $Z/divunal.com \
+    --pyzone $Z/ynchrono.us \
+    --pyzone $Z/divmod.com \
+    --pyzone $Z/divmod.org \
+    --pyzone $Z/crookedsapling.us

--- a/services/t-names/zones/crookedsapling.us
+++ b/services/t-names/zones/crookedsapling.us
@@ -1,0 +1,39 @@
+from twisted.names.authority import getSerial
+
+from hosts import nameservers, addSubdomains
+
+name = 'crookedsapling.us'
+
+zone = [
+    SOA(
+        # For whom we are the authority
+        name,
+
+        # This nameserver's name
+        mname = "ns1.twistedmatrix.com",
+
+        # Mailbox of individual who handles this
+        rname = "exarkun.twistedmatrix.com",
+
+        # Unique serial identifying this SOA data
+        # <4-year> <2-month> <2-day> <2-counter>
+        serial = getSerial(),
+
+        # Time interval before zone should be refreshed
+        refresh = "5M",
+
+        # Interval before failed refresh should be retried
+        retry = "15M",
+
+        # Upper limit on time interval before expiry
+        expire = "1H",
+
+        # Minimum TTL
+        minimum = "5M",
+
+        ttl="5M",
+    ),
+
+    CNAME(name, 'watchthis.farmr.com', ttl='5M'),
+    CNAME('lyra.' + name, 'relay.s3auth.com', ttl='5M'),
+] + nameservers(name)

--- a/services/t-names/zones/divmod.com
+++ b/services/t-names/zones/divmod.com
@@ -1,0 +1,46 @@
+from twisted.names.authority import getSerial
+
+from hosts import tmtl
+
+subs = ['mail.']
+name = 'divmod.com'
+
+zone = [
+    SOA(
+        # For whom we are the authority
+        name,
+
+        # This nameserver's name
+        mname = "ns1.twistedmatrix.com",
+
+        # Mailbox of individual who handles this
+        rname = "exarkun.twistedmatrix.com",
+
+        # Unique serial identifying this SOA data
+        # <4-year> <2-month> <2-day> <2-counter>
+        serial = getSerial(),
+
+        # Time interval before zone should be refreshed
+        refresh = "1H",
+
+        # Interval before failed refresh should be retried
+        retry = "15M",
+
+        # Upper limit on time interval before expiry
+        expire = "1H",
+
+        # Minimum TTL
+        minimum = "1H",
+
+        # Default TTL for records in this zone
+        ttl="1H",
+    ),
+
+    NS(name, 'ns1.twistedmatrix.com'),
+    NS(name, 'ns2.twistedmatrix.com'),
+
+    MX(name, 100, 'mail.divmod.com', ttl=5 * 60),
+]
+
+for sub in subs:
+    zone.append(A(sub + name, tmtl, ttl="1H"))

--- a/services/t-names/zones/divmod.org
+++ b/services/t-names/zones/divmod.org
@@ -1,0 +1,47 @@
+from twisted.names.authority import getSerial
+
+from hosts import addSubdomains, tmtl
+
+name = 'divmod.org'
+subs = {
+     tmtl: ['www.', ''],
+     }
+
+zone = [
+    SOA(
+        # For whom we are the authority
+        name,
+
+        # This nameserver's name
+        mname = "ns1.twistedmatrix.com",
+
+        # Mailbox of individual who handles this
+        rname = "exarkun.twistedmatrix.com",
+
+        # Unique serial identifying this SOA data
+        # <4-year> <2-month> <2-day> <2-counter>
+        serial = getSerial(),
+
+        # Time interval before zone should be refreshed
+        refresh = "1H",
+
+        # Interval before failed refresh should be retried
+        retry = "15M",
+
+        # Upper limit on time interval before expiry
+        expire = "1H",
+
+        # Minimum TTL
+        minimum = "1H",
+
+        # Default TTL for records in this zone
+        ttl="1H",
+    ),
+
+    NS(name, 'ns1.twistedmatrix.com'),
+    NS(name, 'ns2.twistedmatrix.com'),
+
+    MX(name, 100, 'tm.tl', ttl=5 * 60),
+    ]
+
+addSubdomains('divmod.org', zone, subs)

--- a/services/t-names/zones/divunal.com
+++ b/services/t-names/zones/divunal.com
@@ -1,0 +1,43 @@
+
+from twisted.names.authority import getSerial
+
+name = 'divunal.com'
+
+from hosts import dornkirk, tmtl, nameservers, addSubdomains
+
+subs = {
+    dornkirk: [''],
+}
+
+zone = [
+    SOA(
+        # For whom we are the authority
+        name,
+
+        # This nameserver's name
+        mname = "ns1.twistedmatrix.com",
+
+        # Mailbox of individual who handles this
+        rname = "radix.twistedmatrix.com",
+
+        # Unique serial identifying this SOA data
+        # <4-year> <2-month> <2-day> <2-counter>
+        serial = getSerial(),
+
+        # Time interval before zone should be refreshed
+        refresh = "15M",
+
+        # Interval before failed refresh should be retried
+        retry = "1H",
+
+        # Upper limit on time interval before expiry
+        expire = "1H",
+
+        # Minimum TTL
+        minimum = "1H"
+    ),
+
+    MX(name, 10, 'mail.twistedmatrix.com'),
+] + nameservers(name)
+
+addSubdomains(name, zone, subs)

--- a/services/t-names/zones/hosts.py
+++ b/services/t-names/zones/hosts.py
@@ -1,0 +1,47 @@
+
+from twisted.names.dns import Record_NS, Record_A
+
+
+pyramid = '198.49.126.190'
+neutrino = '198.49.126.149'
+wolfwood = '66.35.48.24'
+planet = 'mag.ik.nu'
+xpdev = '66.219.41.216'
+tmrc = '18.150.1.81'
+tesla = '78.46.87.228'
+intarweb = '198.49.126.149'
+cube = '66.35.39.65'
+pyramid = '198.49.126.190'
+boson = '209.6.87.187'
+googleHosting = 'ghs.google.com'
+paper = '67.207.132.219'
+posterous = '66.216.125.32'
+tmtl = '198.101.153.251'
+oloid = '64.90.56.39'
+dornkirk = '66.35.39.66'
+
+buildmaster = '162.209.125.89'
+
+
+def nameservers(host, *addresses):
+    """
+    Return NS records and A record glue for the given host.
+    """
+    if not addresses:
+        addresses = [dornkirk, tmtl, buildmaster]
+    records = []
+    for i, addr in enumerate(addresses):
+        records.extend([
+            (host, Record_NS('ns%d.twistedmatrix.com' % (i + 1,), ttl='1H')),
+            ('ns%d.twistedmatrix.com' % (i + 1,), Record_A(addr, ttl='1H'))
+        ])
+    return records
+
+
+def addSubdomains(host, zone, subs):
+    """
+    Add the given subdomain mapping to the given zone list.
+    """
+    for (ip, hosts) in subs.items():
+        for sub in hosts:
+            zone.append((sub + host, Record_A(ip, ttl="5M")))

--- a/services/t-names/zones/twistedmatrix.com
+++ b/services/t-names/zones/twistedmatrix.com
@@ -1,0 +1,58 @@
+
+from twisted.names.authority import getSerial
+
+name = 'twistedmatrix.com'
+
+from hosts import cube, dornkirk, tmtl, oloid, wolfwood, xpdev, planet, nameservers, addSubdomains, googleHosting
+
+subs = {
+    cube: ['cube.'],
+    wolfwood: ['cvs.', 'wolfwood.', 'svn.', 'git.', 'code.'],
+    oloid: ['oloid.'],
+    dornkirk: ['dornkirk.', '', 'projects.', 'ftp.', 'www.', 'buildbot.', 'speed.',
+               'reality.', 'irc.', 'saph.',
+               'java.', 'smtp.', 'mail.'],
+    xpdev: ['xpdev.'],
+}
+
+zone = [
+    SOA(
+        # For whom we are the authority
+        name,
+
+        # This nameserver's name
+        mname = "ns1.twistedmatrix.com",
+
+        # Mailbox of individual who handles this
+        rname = "radix.twistedmatrix.com",
+
+        # Unique serial identifying this SOA data
+        # <4-year> <2-month> <2-day> <2-counter>
+        serial = getSerial(),
+
+        # Time interval before zone should be refreshed
+        refresh = "5M",
+
+        # Interval before failed refresh should be retried
+        retry = "15M",
+
+        # Upper limit on time interval before expiry
+        expire = "1H",
+
+        # Minimum TTL
+        minimum = "5M",
+
+        ttl="5M",
+    ),
+
+    MX(name, 5, 'mail.' + name, ttl='1H'),
+
+    CNAME('planet.twistedmatrix.com', planet, ttl='1D'),
+    CNAME('radix.twistedmatrix.com', 'wordeology.com', ttl='1D'),
+    CNAME('washort.twistedmatrix.com', googleHosting, ttl='1D'),
+    CNAME('glyph.twistedmatrix.com', 'writing.glyph.im', ttl='1D'),
+    CNAME('secret.glyph.twistedmatrix.com', googleHosting, ttl='1D'),
+    CNAME('labs.twistedmatrix.com', googleHosting, ttl='1D'),
+] + nameservers(name)
+
+addSubdomains(name, zone, subs)

--- a/services/t-names/zones/ynchrono.us
+++ b/services/t-names/zones/ynchrono.us
@@ -1,0 +1,50 @@
+
+from twisted.names.authority import getSerial
+
+name = 'ynchrono.us'
+
+from hosts import dornkirk, tmtl, addSubdomains
+
+subs = {
+    dornkirk: ['ns1.', ''],
+    tmtl: ['ns2.', ''],
+    '104.130.225.186': ['chronology.'],
+}
+
+zone = [
+    SOA(
+        # For whom we are the authority
+        name,
+
+        # This nameserver's name
+        mname = "ns1.twistedmatrix.com",
+
+        # Mailbox of individual who handles this
+        rname = "exarkun.twistedmatrix.com",
+
+        # Unique serial identifying this SOA data
+        # <4-year> <2-month> <2-day> <2-counter>
+        serial = getSerial(),
+
+        # Time interval before zone should be refreshed
+        refresh = "1H",
+
+        # Interval before failed refresh should be retried
+        retry = "1H",
+
+        # Upper limit on time interval before expiry
+        expire = "21D",
+
+        # Minimum TTL
+        minimum = "1H"
+    ),
+
+    NS(name, 'ns1.ynchrono.us'),
+    NS(name, 'ns2.ynchrono.us'),
+
+    CNAME('as.ynchrono.us', 'ghs.google.com.', ttl='1D'),
+    CNAME('s.ynchrono.us', 's.ynchrono.us.s3-website-us-east-1.amazonaws.com'),
+
+]
+
+addSubdomains(name, zone, subs)


### PR DESCRIPTION
Scope
=====

We want to move t-names braid config from a submodule to a simple subfolder in braid.

Changes
=======

Removed submodule and copied files from https://github.com/twisted-infra/t-names.

Update fabfile.py to update files from submodule, rather than git repo

twisted-infra/t-names was updated to inform that code is not in braid.
No need to migrate issues or PRs.

How to test
=========

```
# Install and start it.
fab -i ~/.vagrant.d/insecure_private_key config.vagrant t-names.install
fab -i ~/.vagrant.d/insecure_private_key config.vagrant t-names.start
# You should see some responses
host twistedmatrix.com 172.16.255.140
# Stop it and you should get connection timed out
fab -i ~/.vagrant.d/insecure_private_key config.vagrant t-names.stop
host twistedmatrix.com 172.16.255.140
```