### PR TITLE
Move kenaan submodule into a normal folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "services/diffresource"]
 	path = services/diffresource
 	url = https://github.com/twisted-infra/diffresource
-[submodule "services/kenaan"]
-	path = services/kenaan
-	url = https://github.com/twisted-infra/kenaan
 [submodule "services/mailman"]
 	path = services/mailman
 	url = https://github.com/twisted-infra/mailman-config

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Currently Supported Services
 - [t-web](https://github.com/twisted-infra/t-web)
 - buildbot
 - [diffresource](https://github.com/twisted-infra/diffresource)
-- [kenaan](https://github.com/twisted-infra/kenaan)
+- kenaan
 - [hiscore](svn.twistedmatrix.com:infra/twisted-highscore)
 - [trac](https://github.com/twisted-infra/trac-config)
 - [mailman](https://github.com/twisted-infra/mailman-config)

--- a/services/kenaan/README
+++ b/services/kenaan/README
@@ -1,0 +1,24 @@
+This is the configuration for kenaan, twistedmatrix.com's irc bot.
+
+It is adminstered using braid[1]. It is installed in `/srv/kenaan` as user
+kenaan.
+It uses the following directories
+
+~/config - This repository.
+~/bin - commands to start and stop the server
+  commit - Announce a commit
+  alert - (obsolete) report a munin alert
+  message - Send a message to a channel
+  ticket - Announce a new ticket
+~/log - log files
+~/run - pid files
+
+The following fabric commands are available:
+
+install - Create user and install configuration.
+update - Updates the configuration and restarts the server.
+start - Start server.
+stop - Stop server.
+restart - Restart the server.
+
+[1] https://github.com/twisted-infra/braid

--- a/services/kenaan/_http.py
+++ b/services/kenaan/_http.py
@@ -1,0 +1,338 @@
+
+import urlparse
+import md5, sha
+
+from twisted.web import client, http
+from twisted.internet import reactor
+
+
+class Token(str):
+    __slots__=[]
+    tokens = {}
+    def __new__(self, char):
+        token = Token.tokens.get(char)
+        if token is None:
+            Token.tokens[char] = token = str.__new__(self, char)
+        return token
+
+    def __repr__(self):
+        return "Token(%s)" % str.__repr__(self)
+
+
+http_tokens = " \t\"()<>@,;:\\/[]?={}"
+http_ctls = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f"
+
+
+def tokenize(header, foldCase=True):
+    """Tokenize a string according to normal HTTP header parsing rules.
+
+    In particular:
+     - Whitespace is irrelevant and eaten next to special separator tokens.
+       Its existance (but not amount) is important between character strings.
+     - Quoted string support including embedded backslashes.
+     - Case is insignificant (and thus lowercased), except in quoted strings.
+        (unless foldCase=False)
+     - Multiple headers are concatenated with ','
+
+    NOTE: not all headers can be parsed with this function.
+
+    Takes a raw header value (list of strings), and
+    Returns a generator of strings and Token class instances.
+    """
+    tokens=http_tokens
+    ctls=http_ctls
+
+    string = ",".join(header)
+    list = []
+    start = 0
+    cur = 0
+    quoted = False
+    qpair = False
+    inSpaces = -1
+    qstring = None
+
+    for x in string:
+        if quoted:
+            if qpair:
+                qpair = False
+                qstring = qstring+string[start:cur-1]+x
+                start = cur+1
+            elif x == '\\':
+                qpair = True
+            elif x == '"':
+                quoted = False
+                yield qstring+string[start:cur]
+                qstring=None
+                start = cur+1
+        elif x in tokens:
+            if start != cur:
+                if foldCase:
+                    yield string[start:cur].lower()
+                else:
+                    yield string[start:cur]
+
+            start = cur+1
+            if x == '"':
+                quoted = True
+                qstring = ""
+                inSpaces = False
+            elif x in " \t":
+                if inSpaces is False:
+                    inSpaces = True
+            else:
+                inSpaces = -1
+                yield Token(x)
+        elif x in ctls:
+            raise ValueError("Invalid control character: %d in header" % ord(x))
+        else:
+            if inSpaces is True:
+                yield Token(' ')
+                inSpaces = False
+
+            inSpaces = False
+        cur = cur+1
+
+    if qpair:
+        raise ValueError, "Missing character after '\\'"
+    if quoted:
+        raise ValueError, "Missing end quote"
+
+    if start != cur:
+        if foldCase:
+            yield string[start:cur].lower()
+        else:
+            yield string[start:cur]
+
+
+def parseWWWAuthenticate(tokenized):
+    headers = []
+
+    tokenList = list(tokenized)
+
+    while tokenList:
+        scheme = tokenList.pop(0)
+        challenge = {}
+        last = None
+        kvChallenge = False
+
+        while tokenList:
+            token = tokenList.pop(0)
+            if token == Token('='):
+                kvChallenge = True
+                challenge[last] = tokenList.pop(0)
+                last = None
+
+            elif token == Token(','):
+                if kvChallenge:
+                    if len(tokenList) > 1 and tokenList[1] != Token('='):
+                        break
+
+                else:
+                    break
+
+            else:
+                last = token
+
+        if last and scheme and not challenge and not kvChallenge:
+            challenge = last
+            last = None
+
+        headers.append((scheme, challenge))
+
+    if last and last not in (Token('='), Token(',')):
+        if headers[-1] == (scheme, challenge):
+            scheme = last
+            challenge = {}
+            headers.append((scheme, challenge))
+
+    return headers
+
+
+def parse(url, defaultPort=None):
+    """
+    Split the given URL into the scheme, host, port, and path.
+
+    @type url: C{str}
+    @param url: An URL to parse.
+
+    @type defaultPort: C{int} or C{None}
+    @param defaultPort: An alternate value to use as the port if the URL does
+    not include one.
+
+    @return: A four-tuple of the scheme, host, port, and path of the URL.  All
+    of these are C{str} instances except for port, which is an C{int}.
+    """
+    url = url.strip()
+    parsed = urlparse.urlparse(url)
+    scheme = parsed[0]
+    path = urlparse.urlunparse(('','')+parsed[2:])
+    if defaultPort is None:
+        if scheme == 'https':
+            defaultPort = 443
+        else:
+            defaultPort = 80
+    host, port = parsed[1], defaultPort
+    if ':' in host:
+        host, port = host.split(':')
+        port = int(port)
+    if path == "":
+        path = "/"
+    return scheme, host, port, path
+
+
+def makeGetterFactory(url, factoryFactory, contextFactory=None,
+                      *args, **kwargs):
+    """
+    Create and connect an HTTP page getting factory.
+
+    Any additional positional or keyword arguments are used when calling
+    C{factoryFactory}.
+
+    @param factoryFactory: Factory factory that is called with C{url}, C{args}
+        and C{kwargs} to produce the getter
+
+    @param contextFactory: Context factory to use when creating a secure
+        connection, defaulting to C{None}
+
+    @return: The factory created by C{factoryFactory}
+    """
+    scheme, host, port, path = parse(url)
+    factory = factoryFactory(url, *args, **kwargs)
+    if scheme == 'https':
+        from twisted.internet import ssl
+        if contextFactory is None:
+            contextFactory = ssl.ClientContextFactory()
+        reactor.connectSSL(host, port, factory, contextFactory)
+    else:
+        reactor.connectTCP(host, port, factory)
+    return factory
+
+
+def getPage(url, contextFactory=None, *args, **kwargs):
+    """
+    Download a web page as a string.
+
+    Download a page. Return a deferred, which will callback with a
+    page (as a string) or errback with a description of the error.
+
+    See HTTPClientFactory to see what extra args can be passed.
+    """
+    return makeGetterFactory(
+        url,
+        client.HTTPClientFactory,
+        contextFactory=contextFactory,
+        *args, **kwargs)
+
+algorithms = {
+    'md5': md5.new,
+
+    # md5-sess is more complicated than just another algorithm.  It requires
+    # H(A1) state to be remembered from the first WWW-Authenticate challenge
+    # issued and re-used to process any Authorization header in response to
+    # that WWW-Authenticate challenge.  It is *not* correct to simply
+    # recalculate H(A1) each time an Authorization header is received.  Read
+    # RFC 2617, section 3.2.2.2 and do not try to make DigestCredentialFactory
+    # support this unless you completely understand it. -exarkun
+    'md5-sess': md5.new,
+
+    'sha': sha.new,
+}
+
+# DigestCalcHA1
+def calcHA1(pszAlg, pszUserName, pszRealm, pszPassword, pszNonce, pszCNonce,
+            preHA1=None):
+    """
+    Compute H(A1) from RFC 2617.
+
+    @param pszAlg: The name of the algorithm to use to calculate the digest.
+        Currently supported are md5, md5-sess, and sha.
+    @param pszUserName: The username
+    @param pszRealm: The realm
+    @param pszPassword: The password
+    @param pszNonce: The nonce
+    @param pszCNonce: The cnonce
+
+    @param preHA1: If available this is a str containing a previously
+       calculated H(A1) as a hex string.  If this is given then the values for
+       pszUserName, pszRealm, and pszPassword must be C{None} and are ignored.
+    """
+
+    if (preHA1 and (pszUserName or pszRealm or pszPassword)):
+        raise TypeError(("preHA1 is incompatible with the pszUserName, "
+                         "pszRealm, and pszPassword arguments"))
+
+    if preHA1 is None:
+        # We need to calculate the HA1 from the username:realm:password
+        m = algorithms[pszAlg]()
+        m.update(pszUserName)
+        m.update(":")
+        m.update(pszRealm)
+        m.update(":")
+        m.update(pszPassword)
+        HA1 = m.digest()
+    else:
+        # We were given a username:realm:password
+        HA1 = preHA1.decode('hex')
+
+    if pszAlg == "md5-sess":
+        m = algorithms[pszAlg]()
+        m.update(HA1)
+        m.update(":")
+        m.update(pszNonce)
+        m.update(":")
+        m.update(pszCNonce)
+        HA1 = m.digest()
+
+    return HA1.encode('hex')
+
+
+def calcHA2(algo, pszMethod, pszDigestUri, pszQop, pszHEntity):
+    """
+    Compute H(A2) from RFC 2617.
+
+    @param pszAlg: The name of the algorithm to use to calculate the digest.
+        Currently supported are md5, md5-sess, and sha.
+    @param pszMethod: The request method.
+    @param pszDigestUri: The request URI.
+    @param pszQop: The Quality-of-Protection value.
+    @param pszHEntity: The hash of the entity body or C{None} if C{pszQop} is
+        not C{'auth-int'}.
+    @return: The hash of the A2 value for the calculation of the response
+        digest.
+    """
+    m = algorithms[algo]()
+    m.update(pszMethod)
+    m.update(":")
+    m.update(pszDigestUri)
+    if pszQop == "auth-int":
+        m.update(":")
+        m.update(pszHEntity)
+    return m.digest().encode('hex')
+
+
+def calcResponse(HA1, HA2, algo, pszNonce, pszNonceCount, pszCNonce, pszQop):
+    """
+    Compute the digest for the given parameters.
+
+    @param HA1: The H(A1) value, as computed by L{calcHA1}.
+    @param HA2: The H(A2) value, as computed by L{calcHA2}.
+    @param pszNonce: The challenge nonce.
+    @param pszNonceCount: The (client) nonce count value for this response.
+    @param pszCNonce: The client nonce.
+    @param pszQop: The Quality-of-Protection value.
+    """
+    m = algorithms[algo]()
+    m.update(HA1)
+    m.update(":")
+    m.update(pszNonce)
+    m.update(":")
+    if pszNonceCount and pszCNonce:
+        m.update(pszNonceCount)
+        m.update(":")
+        m.update(pszCNonce)
+        m.update(":")
+        m.update(pszQop)
+        m.update(":")
+    m.update(HA2)
+    respHash = m.digest().encode('hex')
+    return respHash

--- a/services/kenaan/alert
+++ b/services/kenaan/alert
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+
+import sys, os
+
+from twisted.python import log
+
+import config, alert
+
+if __name__ == '__main__':
+    data = sys.stdin.read()[:-1]
+    log.startLogging(
+        file(os.path.expanduser(
+            os.path.join(config.LOG_ROOT, '.alert.log')), 'a'))
+    items = [datum.split('\t') for datum in data.split('\n')]
+    log.msg(repr(data))
+    log.msg(repr(items))
+    alert.main(items)

--- a/services/kenaan/alert.py
+++ b/services/kenaan/alert.py
@@ -1,0 +1,55 @@
+
+from twisted.internet import reactor
+from twisted.spread import pb
+from twisted.python import log
+
+import config
+
+class Alert(pb.Copyable, pb.RemoteCopy):
+    def __init__(self, hostname, service, returncode, output):
+        self.hostname = hostname
+        self.service = service
+        self.returncode = returncode
+        self.output = output
+
+    def __repr__(self):
+        return 'Alert(%r, %r, %r, %r)' % (
+            self.hostname, self.service,
+            self.returncode, self.output)
+pb.setUnjellyableForClass(Alert, Alert)
+
+class MuninAlertListener:
+    """
+    Mixin for a PB Referenceable which accepts Munin alerts.
+    """
+    def remote_alert(self, alert):
+        self.proto.alert(alert)
+
+
+class MuninAlert:
+    alertMessageFormat = (
+        'Alert from %(hostname)s [%(service)s]: %(output)s')
+
+    def alert(self, alert):
+        self.join(config.ALERT_CHANNEL)
+        self.msg(
+            config.ALERT_CHANNEL,
+            self.alertMessageFormat % vars(alert),
+            config.LINE_LENGTH)
+
+def _sendAlert(alert):
+    cf = pb.PBClientFactory()
+    reactor.connectTCP(config.BOT_HOST, config.BOT_PORT, cf)
+
+    def cbRoot(rootObj):
+        return rootObj.callRemote('alert', alert)
+
+    rootD = cf.getRootObject()
+    rootD.addCallback(cbRoot)
+    rootD.addErrback(log.err)
+    rootD.addCallback(lambda ign: reactor.stop())
+
+def main(alerts):
+    reactor.callWhenRunning(lambda: [_sendAlert(Alert(hostname, service, returncode, output))
+                                       for (hostname, service, returncode, output) in alerts])
+    reactor.run()

--- a/services/kenaan/commit
+++ b/services/kenaan/commit
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+
+import sys, os
+
+from twisted.python import log
+
+import config, commit
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        raise SystemExit("Usage: %s <repository path> <revision number>" % (sys.argv[0],))
+    log.startLogging(
+        file(os.path.expanduser(
+            os.path.join(config.LOG_ROOT, '.commit.log')), 'a'))
+    commit.main(sys.argv[1], int(sys.argv[2]))

--- a/services/kenaan/commit.py
+++ b/services/kenaan/commit.py
@@ -1,0 +1,227 @@
+
+import os, re
+
+from twisted.internet import reactor, protocol, defer
+from twisted.python import log
+from twisted.spread import pb
+
+import config
+
+SVNLOOK = '/usr/bin/svnlook'
+
+ADDED = 'A'
+DELETED = 'D'
+MODIFIED = 'U'
+
+class Change(pb.Copyable, pb.RemoteCopy):
+    def __init__(self, path, changeType, propchange=False):
+        self.path = path
+        self.changeType = changeType
+        self.propchange = propchange
+
+    def __str__(self):
+        mod = self.changeType
+        if self.propchange:
+            mod = '_' + mod
+        return mod + ' ' + self.path
+
+    def __repr__(self):
+        return 'Change(%r, %r, propchange=%r)' % (
+            self.path, self.changeType, self.propchange)
+
+    def fromString(cls, status):
+        parts = status.split(None, 1)
+        propchange = '_' in parts[0]
+        return cls(parts[1], parts[0][-1:], propchange)
+    fromString = classmethod(fromString)
+pb.setUnjellyableForClass(Change, Change)
+
+class _Look(protocol.ProcessProtocol):
+    def __init__(self, onDone):
+        self.onDone = onDone
+
+    def connectionMade(self):
+        self.out = []
+        self.err = []
+        self.transport.closeStdin()
+
+    def outReceived(self, bytes):
+        self.out.append(bytes)
+
+    def errReceived(self, bytes):
+        self.err.append(bytes)
+
+    def processEnded(self, reason):
+        if self.err:
+            log.msg("Error output received:")
+            log.msg(repr(''.join(self.err)))
+            log.msg("Standard output received:")
+            log.msg(repr(''.join(self.out)))
+            self.onDone.errback(Exception("Something went wrong",
+                                          ''.join(self.err),
+                                          ''.join(self.out)))
+        else:
+            self.onDone.callback(self.done(''.join(self.out)))
+
+class LookInfo(_Look):
+    def done(self, bytes):
+        lines = bytes.strip().splitlines()
+        author, date, logMsgSize = lines[:3]
+        logMsg = lines[3:]
+        return author, logMsg
+
+class LookChanged(_Look):
+    def done(self, bytes):
+        return map(Change.fromString, bytes.splitlines())
+
+class RepositoryChangeListener:
+    """
+    Mixin for a PB Referenceable which accepts repository change
+    notifications.
+    """
+    def remote_change(self, repo, rev, author, msg, changes):
+        log.msg("change(%r, %r, %r, %r, %r)" % (repo, rev, author, msg, changes))
+        self.proto.change(repo, rev, author, msg, changes)
+
+class RepositoryChange:
+    def sendChangeTo(self, channel, repo, rev, author, msg, changes):
+        self.join(channel)
+        msg = msg[0]
+        fmt = '\x0303%(author)s \x0310r%(rev)s\x0314%(prefix)s%(changes)s\x0f: %(msg)s'
+        adds = []
+        deletes = []
+        modifies = []
+
+        if len(changes) > 1:
+            pfx = '/'.join(os.path.commonprefix([ch.path.split('/') for ch in changes]))
+            if pfx:
+                prefix = ' ' + pfx
+                for ch in changes:
+                    ch.path = ch.path[len(pfx):]
+            else:
+                prefix = ''
+        else:
+            prefix = ''
+
+        for ch in changes:
+            if len(changes) == 1 or ch.path.endswith('/'):
+                p = ch.path
+            else:
+                p = os.path.basename(ch.path)
+            if p:
+                if ch.propchange:
+                    p = p + '*'
+                {ADDED: adds,
+                 DELETED: deletes,
+                 MODIFIED: modifies}[ch.changeType].append(p)
+
+        # Not a rigorous max group length enforcement thingy, but a
+        # reasonable heuristic.  Make it better later.
+        M = 15
+        if len(adds) + len(deletes) + len(modifies) > M:
+            L = [adds, deletes, modifies]
+            L.sort(key=len)
+            del L[2][M - (len(L[0]) + len(L[1])):]
+            L[2].append('...')
+
+        changes = ((adds and ' \x0305A(' + ' '.join(adds) + ')' or '') +
+                   (deletes and ' \x0306D(' + ' '.join(deletes) + ')' or '') +
+                   (modifies and ' \x0307M(' + ' '.join(modifies) + ')' or ''))
+        trailer = ' ...'
+        ircmsg = fmt % locals()
+        ircmsg = ircmsg[:240 - len(trailer)] + trailer
+
+        # Freenode kind of sucks.
+        self.msg(channel, ircmsg, config.LINE_LENGTH)
+
+    def change(self, repo, rev, author, msg, changes):
+        sentTo = []
+        for (repoRule, pathRule, channels) in config.COMMIT_RULES:
+            for channel in channels:
+                if channel in sentTo:
+                    continue
+                if re.match(repoRule, repo):
+                    for change in changes:
+                        if re.match(pathRule, change.path):
+                            self.sendChangeTo(
+                                channel,
+                                repo,
+                                rev,
+                                author,
+                                msg,
+                                # This is pretty lame, but it is the easiest
+                                # way to not have to touch the logic in
+                                # sendChangeTo, which mutates Change
+                                # instances (because it is stupid).
+                                [Change(ch.path, ch.changeType, ch.propchange)
+                                 for ch
+                                 in changes])
+                            sentTo.append(channel)
+                            break
+
+def _collect(repo, rev):
+    infoD = defer.Deferred()
+    changedD = defer.Deferred()
+    reactor.spawnProcess(LookInfo(infoD), SVNLOOK, args=('svnlook', 'info',
+                                                         repo, '--revision',
+                                                         str(rev)))
+    reactor.spawnProcess(LookChanged(changedD), SVNLOOK, args=('svnlook',
+                                                               'changed',
+                                                               repo,
+                                                               '--revision',
+                                                               str(rev)))
+    return defer.DeferredList([infoD, changedD])
+
+def _report(((infoSuccess, infoResult), (changeSuccess, changeResult)),
+            repo, rev):
+    if not infoSuccess:
+        return infoResult
+    if not changeSuccess:
+        return changeResult
+
+    # Connect
+    def cbRoot(rootObj):
+        return rootObj.callRemote(
+            'change',
+            repo=repo, rev=rev,
+            author=infoResult[0], msg=infoResult[1],
+            changes=changeResult)
+    cf = pb.PBClientFactory()
+    reactor.connectTCP(config.BOT_HOST, config.BOT_PORT, cf)
+    rootD = cf.getRootObject()
+    rootD.addCallback(cbRoot)
+    return rootD
+
+def _collectAndReport(repo, rev):
+    d = _collect(repo, rev)
+    d.addCallback(_report, repo, rev)
+    d.addErrback(log.err)
+    d.addCallback(lambda ign: reactor.stop())
+
+
+
+def _unblockAll():
+    import ctypes
+
+    SIG_SETMASK = 2
+
+    libc = ctypes.CDLL('libc.so.6')
+    sigprocmask = libc.sigprocmask
+    sigprocmask.restype = ctypes.c_int
+    sigprocmask.argtypes = [ctypes.c_int, ctypes.POINTER(ctypes.c_long), ctypes.POINTER(ctypes.c_long)]
+    new = ctypes.c_long(0)
+    old = ctypes.c_long(0)
+    print 'sigprocmask result:', sigprocmask(SIG_SETMASK, ctypes.pointer(new), ctypes.pointer(old))
+    print 'old signal mask was:', old
+
+
+
+def main(repo, rev):
+
+    # In case invoked from mod_dav_svn, fix the signal mask.  As far as I
+    # can tell, Apache blocks a crapload of stuff - most importantly SIGCHLD
+    # - and we inherit that, breaking us.
+    _unblockAll()
+
+    reactor.callWhenRunning(_collectAndReport, repo, rev)
+    reactor.run()

--- a/services/kenaan/commit_bot.py
+++ b/services/kenaan/commit_bot.py
@@ -1,0 +1,64 @@
+from twisted.words.protocols import irc
+from twisted.internet import reactor
+from twisted.spread import pb
+
+import config
+
+# XXX Plugins or something, jeez stupid.
+import commit, ticket, alert, message
+
+class Notifications(pb.Root, commit.RepositoryChangeListener, ticket.TicketChangeListener, alert.MuninAlertListener, message.MessageListener):
+    def __init__(self, proto):
+        self.proto = proto
+
+
+class CommitBot(irc.IRCClient, commit.RepositoryChange, ticket.TicketChange, ticket.TicketReview, alert.MuninAlert, message.Message):
+
+    lineRate = config.LINE_RATE
+
+    notificationPort = None
+
+    def __init__(self, nickname, password):
+        self.nickname = nickname
+        self.password = password
+
+    def connectionLost(self, reason):
+        if self.notificationPort is not None:
+            self.notificationPort.stopListening()
+
+        for cls in self.__class__.__bases__[1:]:
+            try:
+                f = cls.connectionLost
+            except AttributeError:
+                pass
+            else:
+                f(self, reason)
+
+
+    def signedOn(self):
+        self.factory.resetDelay()
+        sf = pb.PBServerFactory(Notifications(self))
+        self.notificationPort = reactor.listenTCP(
+            config.BOT_PORT, sf)
+
+        for cls in self.__class__.__bases__[1:]:
+            try:
+                f = cls.signedOn
+            except AttributeError:
+                pass
+            else:
+                f(self)
+
+
+    def noticed(self, user, channel, message):
+        pass
+
+
+    def privmsg(self, user, channel, message):
+        for cls in self.__class__.__bases__[1:]:
+            try:
+                f = cls.privmsg
+            except AttributeError:
+                pass
+            else:
+                f(self, user, channel, message)

--- a/services/kenaan/commit_bot.tac
+++ b/services/kenaan/commit_bot.tac
@@ -1,0 +1,18 @@
+from functools import partial
+from twisted.application import service, internet
+from twisted.internet.protocol import ReconnectingClientFactory
+
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+del sys, os
+
+import private as config
+from commit_bot import CommitBot
+
+application = service.Application('kenaan')
+
+factory = ReconnectingClientFactory.forProtocol(
+		partial(CommitBot, nickname=config.BOT_NICK, password=config.BOT_PASS))
+
+svc = internet.TCPClient(config.IRC_SERVER, config.IRC_PORT, factory)
+svc.setServiceParent(application)

--- a/services/kenaan/config.py
+++ b/services/kenaan/config.py
@@ -1,0 +1,40 @@
+# Hostname where persistent bot process is listening
+BOT_HOST = 'twistedmatrix.com'
+
+# Port number of same
+BOT_PORT = 15243
+
+# Maximum number of characters to put into a single IRC message
+LINE_LENGTH = 400
+
+# Delay, in seconds, between IRC messages
+LINE_RATE = 1.0
+
+# Three-tuples of (repository path, filename expression, channel) defining
+# the rules for announcing commit messages.
+COMMIT_RULES = [
+    ('/svn/Twisted', '.*', ['#twisted', '#twisted-dev']),
+    ('/svn/Twisted', '.*/(twisted|doc)/web2?/.*', ['#twisted.web', '#twisted-dev']),
+    ('/svn/WebSite', '.*', ['#twisted', '#twisted-dev']),
+    ('/svn', 'pypy/.*', ['#pypy'])]
+
+# Two-tuples of (tracker URL, channel) defining the rules for announcing
+# ticket changes.
+TICKET_RULES = [
+    ('http://twistedmatrix.com/trac/', ['#twisted', '#twisted-dev']),
+    ]
+
+# The channel to which to send alerts.
+ALERT_CHANNEL = '#twisted-admin'
+
+# The directory in which log files will be written.  Most users can
+# write to their own home directory, but some can't - eg www-data.
+# So, give each user a directory in /tmp.  They can't use /tmp itself
+# because users won't be able to open log files written by other
+# users.
+import os, pwd, tempfile
+LOG_ROOT = os.path.join(
+    tempfile.gettempdir(),
+    'kenaan-logs-' + pwd.getpwuid(os.getuid()).pw_name)
+if not os.path.isdir(LOG_ROOT):
+    os.makedirs(LOG_ROOT)

--- a/services/kenaan/crontab
+++ b/services/kenaan/crontab
@@ -1,0 +1,1 @@
+@reboot ~/bin/start

--- a/services/kenaan/fabfile.py
+++ b/services/kenaan/fabfile.py
@@ -1,0 +1,80 @@
+"""
+Support for kenaan service installation and management.
+"""
+
+from fabric.api import run, settings, env, cd, abort, puts, put
+from fabric.contrib import files
+
+from twisted.python.filepath import FilePath
+from twisted.python.util import sibpath
+
+from braid import git, cron, pip
+from braid.twisted import service
+
+# TODO: Move these somewhere else and make them easily extendable
+from braid import config
+_hush_pyflakes = [ config ]
+
+
+class Kenaan(service.Service):
+    def task_install(self):
+        """
+        Install kenaan, an irc bot.
+        """
+        # Bootstrap a new service environment
+        self.bootstrap()
+
+        with settings(user=self.serviceUser):
+            pip.install('amptrac')
+            run('/bin/ln -nsf {}/start {}/start'.format(self.configDir, self.binDir))
+            for bin in ['alert', 'commit', 'message', 'ticket']:
+                run('/bin/ln -nsf {1}/{0} {2}/{0}'.format(bin, self.configDir, self.binDir))
+            self.update()
+            cron.install(self.serviceUser, '{}/crontab'.format(self.configDir))
+            if env.get('installTestData'):
+                self.task_installTestData()
+            elif env.get('installPrivateData'):
+                self.task_installPrivateData()
+
+
+    def task_installTestData(self, force=None):
+        """
+        Do test environment setup (with fake passwords, etc).
+        """
+        if env.get('environment') == 'production':
+           abort("Don't use testInit in production.")
+
+        with settings(user=self.serviceUser), cd(self.configDir):
+            if force or not files.exists('private.py'):
+                puts('Using sample private.py')
+                run('/bin/cp private.py.sample private.py')
+
+
+    def task_installPrivateData(self, private=sibpath(__file__, 'private.py')):
+        """
+        Install private config.
+        """
+        with settings(user=self.serviceUser):
+            if FilePath(private).exists():
+                put(private, '{}/private.py'.format(self.configDir), mode=0600)
+            else:
+                abort('Missing private config.')
+
+
+    def update(self):
+        """
+        Update config.
+        """
+        with settings(user=self.serviceUser):
+            git.branch('https://github.com/twisted-infra/kenaan', self.configDir)
+
+
+    def task_update(self):
+        """
+        Update config and restart.
+        """
+        self.update()
+        self.task_restart()
+
+
+globals().update(Kenaan('kenaan').getTasks())

--- a/services/kenaan/fabfile.py
+++ b/services/kenaan/fabfile.py
@@ -31,10 +31,6 @@ class Kenaan(service.Service):
                 run('/bin/ln -nsf {1}/{0} {2}/{0}'.format(bin, self.configDir, self.binDir))
             execute(self.update)
             cron.install(self.serviceUser, '{}/crontab'.format(self.configDir))
-            if env.get('installPrivateData'):
-                execute(self.task_installPrivateData)
-            else:
-                execute(self.task_installTestData)
 
 
     def task_installTestData(self, force=None):
@@ -70,6 +66,11 @@ class Kenaan(service.Service):
             put(
                 os.path.dirname(__file__) + '/*', self.configDir,
                 mirror_local_mode=True)
+
+            if env.get('installPrivateData'):
+                execute(self.task_installPrivateData)
+            else:
+                execute(self.task_installTestData)
 
 
     def task_update(self):

--- a/services/kenaan/message
+++ b/services/kenaan/message
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+
+import os, sys
+
+from twisted.python.log import startLogging
+
+import config, message
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        raise SystemExit("Usage: %s <channel> <message>" % (sys.argv[0],))
+    startLogging(file(
+        os.path.expanduser(
+            os.path.join(config.LOG_ROOT, '.message.log')), 'a'))
+    message.main(*sys.argv[1:])

--- a/services/kenaan/message.py
+++ b/services/kenaan/message.py
@@ -1,0 +1,57 @@
+
+from twisted.python.log import err
+from twisted.internet import reactor
+from twisted.spread.pb import PBClientFactory
+
+from config import BOT_HOST, BOT_PORT, LINE_LENGTH
+
+class MessageListener:
+    """
+    Mixin for a PB Referenceable which accepts arbitrary messages.
+    """
+    def remote_message(self, channel, message):
+        """
+        Forward the given message to C{self.proto}.
+        """
+        self.proto.message(channel, message)
+
+
+
+class Message:
+    def message(self, channel, message):
+        if channel.startswith('#'):
+            self.join(channel)
+        self.msg(channel, message, LINE_LENGTH)
+
+
+
+def _sendMessage(channel, message):
+    """
+    Establish a connection to the bot and direct it to send the given message
+    to the given channel.
+
+    @type channel: C{str}
+    @type message: C{str}
+    """
+    messageFactory = PBClientFactory()
+    reactor.connectTCP(BOT_HOST, BOT_PORT, messageFactory)
+
+    def cbGotRoot(rootObj):
+        return rootObj.callRemote('message', channel, message)
+
+    rootDeferred = messageFactory.getRootObject()
+    rootDeferred.addCallback(cbGotRoot)
+    rootDeferred.addErrback(err)
+    rootDeferred.addCallback(lambda ign: reactor.stop())
+
+def main(channel, message):
+    """
+    Send the given message to the given channel and run the reactor until it's
+    sent.
+
+    @type channel: C{str}
+    @type message: C{str}
+    """
+    reactor.callWhenRunning(_sendMessage, channel, message)
+    reactor.run()
+

--- a/services/kenaan/private.py.sample
+++ b/services/kenaan/private.py.sample
@@ -1,0 +1,9 @@
+# Hostname of the IRC server to which we will connect
+IRC_SERVER = 'irc.freenode.net'
+IRC_PORT = 6667
+
+# Nickname to use on that IRC server
+BOT_NICK = 'kenaan7'
+
+# Password for this nickname
+BOT_PASS = 'abcdefg'

--- a/services/kenaan/start
+++ b/services/kenaan/start
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+~pypy/bin/twistd \
+    --logfile ~/log/twistd.log \
+    --pidfile ~/run/twistd.pid \
+    --rundir ~/run \
+    --python ~/config/commit_bot.tac

--- a/services/kenaan/ticket
+++ b/services/kenaan/ticket
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+
+import sys, os
+
+from twisted.python import log
+
+import config, ticket
+
+if __name__ == '__main__':
+    if len(sys.argv) != 7:
+        raise SystemExit("Usage: %s <tracker url> <ticket id> <author> <kind> <component> <subject>" % (sys.argv[0],))
+    log.startLogging(
+        file(os.path.expanduser(
+            os.path.join(config.LOG_ROOT, '.ticket.log')), 'a'))
+    ticket.main(*sys.argv[1:])

--- a/services/kenaan/ticket.py
+++ b/services/kenaan/ticket.py
@@ -1,0 +1,178 @@
+
+import urlparse
+
+from twisted.internet import reactor, task, defer
+from twisted.spread import pb
+from twisted.python import log, failure
+try:
+    from amptrac import client as amptrac
+except ImportError as e:
+    amptrac = None
+    amptracError = e
+
+import config
+
+
+class Ticket(pb.Copyable, pb.RemoteCopy):
+    def __init__(self, tracker, id, author, kind, component, subject):
+        self.tracker = tracker
+        self.id = id
+        self.author = author
+        self.kind = kind
+        self.component = component
+        self.subject = subject
+
+    def __repr__(self):
+        return 'Ticket(%r, %d, %r, %r, %r, %r)' % (
+            self.tracker, self.id, self.author, self.kind,
+            self.component, self.subject)
+pb.setUnjellyableForClass(Ticket, Ticket)
+
+
+
+class TicketChangeListener:
+    """
+    Mixin for a PB Referenceable which accepts ticket change notifications.
+    """
+    def remote_ticket(self, ticket):
+        log.msg(str(ticket))
+        self.proto.ticket(ticket)
+
+
+
+class TicketChange:
+    ticketMessageFormat = (
+        'new %(component)s %(kind)s https://tm.tl/#%(id)d by %(author)s: %(subject)s')
+
+    def ticket(self, ticket):
+        for (url, channels) in config.TICKET_RULES:
+            scheme, netloc, path, params, query, fragment = urlparse.urlparse(url)
+            if '@' in netloc:
+                netloc = netloc.split('@', 1)[1]
+            url = urlparse.urlunparse((scheme, netloc, path, params, query, fragment))
+            if ticket.tracker == url:
+                for channel in channels:
+                    self.join(channel)
+                    self.msg(
+                        channel,
+                        self.ticketMessageFormat % vars(ticket),
+                        config.LINE_LENGTH)
+
+
+
+class TicketReview:
+    """
+    Automated review ticket reporting.
+    """
+
+    _ticketCall = None
+
+    def signedOn(self):
+        self._ticketCall = task.LoopingCall(self.reportAllReviewTickets)
+        self._ticketCall.start(60 * 60 * 5)
+
+
+    def privmsg(self, user, channel, message):
+        if 'review branches' in message:
+            for (url, channels) in config.TICKET_RULES:
+                for existing_channel in channels:
+                    if existing_channel == channel:
+                        d = self.reportReviewTickets(url, channel)
+                        d.addErrback(
+                            log.err,
+                            "Failed to satisfy review ticket request from "
+                            "%r to %r" % (url, channel))
+
+
+    def connectionLost(self, reason):
+        if self._ticketCall is not None:
+            self._ticketCall.stop()
+
+
+    def reportAllReviewTickets(self):
+        """
+        Call L{reportReviewTickets} with each element of L{config.TICKET_RULES}.
+        """
+        for (url, channels) in config.TICKET_RULES:
+            for channel in channels:
+                d = self.reportReviewTickets(url, channel)
+                d.addErrback(
+                    log.err,
+                    "Failed to report review tickets from %r to %r" % (
+                        url, channel))
+
+
+    def reportReviewTickets(self, trackerRoot, channel):
+        """
+        Retrieve the list of tickets currently up for review from the
+        tracker at the given location and report them to the given channel.
+
+        @param trackerRoot: The base URL of the trac instance from which to
+        retrieve ticket information.  C{"http://example.com/trac/"}, for
+        example.
+
+        @param channel: The channel to which to send the results.
+
+        @return: A Deferred which fires when the report has been completed.
+        """
+        if amptrac is None:
+            f = failure.Failure(amptracError)
+            log.err(f, "amptrac not present, can't report tickets.")
+            return defer.fail(f)
+
+        d = amptrac.connect(reactor)
+        d.addCallback(self._getReviewTickets)
+        d.addCallback(self._reportReviewTickets, channel)
+        return d
+
+
+    def _getReviewTickets(self, client):
+        """
+        Retrieve the list of tickets currently up for review from the
+        tracker at the given location.
+
+        @return: A Deferred which fires with a C{list} of C{int}s.  Each
+        element is the number of a ticket up for review.
+        """
+        return client.reviewTickets()
+
+
+    def _reportReviewTickets(self, reviewTicketInfo, channel):
+        """
+        Format the given list of ticket numbers and send it to the given channel.
+        """
+        tickets = self._formatTicketNumbers(reviewTicketInfo)
+        self.join(channel)
+        if tickets:
+            message = "Tickets pending review: https://tm.tl/" + tickets
+        else:
+            message = "No tickets pending review!"
+        self.msg(channel, message)
+
+
+    def _formatTicketNumbers(self, reviewTicketInfo):
+        tickets = []
+        for ticket in reviewTicketInfo:
+            if ticket['owner']:
+                tickets.append('#%d (%s)' % (ticket['id'], ticket['owner']))
+            else:
+                tickets.append('#%d' % (ticket['id'],))
+        return ', '.join(tickets).encode('utf-8')
+
+
+
+def _sendTicket(ticket):
+    cf = pb.PBClientFactory()
+    reactor.connectTCP(config.BOT_HOST, config.BOT_PORT, cf)
+
+    def cbRoot(rootObj):
+        return rootObj.callRemote('ticket', ticket)
+
+    rootD = cf.getRootObject()
+    rootD.addCallback(cbRoot)
+    rootD.addErrback(log.err)
+    rootD.addCallback(lambda ign: reactor.stop())
+
+def main(tracker, id, author, kind, component, subject):
+    reactor.callWhenRunning(_sendTicket, Ticket(tracker, int(id), author, kind, component, subject))
+    reactor.run()


### PR DESCRIPTION
Scope
======

We want to move kenaan infra code to a subfolder of braid to make it easier to hack it.

Changes
=======

Removed the subfolder and copy the https://github.com/twisted-infra/kenaan files.

I have updated the fabfile.py to push udpates from local folder.
I have also updated the fabfile.py to also update the private (production/testing) data on each update. 
testing data is now installed when `installPrivateData` is False. so that we can use a single flag for production and staging... similar to what is done for the buildmaster 

I have updated twisted-infra/kenaan repo description and moved the issues to braid and closed old issues.

How to test
=========

I was able to run the install and start the bot but it fails to connect. Most probably due to bad private data and the lack of a staging trac instance.

I hope that once we have a trac instance  (https://github.com/twisted-infra/braid/pull/95) we can come back and update kenaan private staging data to work with the staging trac instance.
