### PR TITLE
Move Amptrac submodule as a folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "services/codespeed"]
 	path = services/codespeed
 	url = https://github.com/twisted-infra/codespeed
-[submodule "services/amptrac"]
-	path = services/amptrac
-	url = https://github.com/twisted-infra/amptrac-config

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ deploy itself on a given machine.
 Currently Supported Services
 ============================
 
+- amptrac
 - t-names
 - [t-web](https://github.com/twisted-infra/t-web)
 - buildbot

--- a/services/amptrac/README
+++ b/services/amptrac/README
@@ -1,0 +1,19 @@
+This is the configuration for twisted's amptrac server.
+
+It is adminstered using braid[1]. It is installed in `/srv/amptrac` as user amptrac.
+It uses the following directories
+
+~/config - This repository.
+~/bin - commands to start and stop the server
+~/log - log files
+~/run - pid files
+
+The following fabric commands are available:
+
+install - Create user and install configuration.
+update - Updates the configuration and restarts the server.
+start - Start server.
+stop - Stop server.
+restart - Restart the server.
+
+[1] https://github.com/twisted-infra/braid

--- a/services/amptrac/crontab
+++ b/services/amptrac/crontab
@@ -1,0 +1,1 @@
+@reboot ~/bin/start

--- a/services/amptrac/fabfile.py
+++ b/services/amptrac/fabfile.py
@@ -1,8 +1,8 @@
 """
 Support for amptrac.
 """
-
-from fabric.api import run, settings
+import os
+from fabric.api import put, run, settings
 
 from braid import cron, git, pip, postgres
 from braid.twisted import service
@@ -33,7 +33,11 @@ class AmpTrac(service.Service):
         Update config.
         """
         with settings(user=self.serviceUser):
-            git.branch('https://github.com/twisted-infra/amptrac-config', self.configDir)
+            run('mkdir -p ' + self.configDir)
+            put(
+                os.path.dirname(__file__) + '/*', self.configDir,
+                mirror_local_mode=True)
+
             amptracSource = 'git+https://github.com/twisted-infra/amptrac-server'
             if _installDeps:
                 pip.install('{}'.format(amptracSource))

--- a/services/amptrac/fabfile.py
+++ b/services/amptrac/fabfile.py
@@ -1,0 +1,52 @@
+"""
+Support for amptrac.
+"""
+
+from fabric.api import run, settings
+
+from braid import cron, git, pip, postgres
+from braid.twisted import service
+from braid.tasks import addTasks
+
+from braid import config
+__all__ = [ 'config' ]
+
+
+class AmpTrac(service.Service):
+    def task_install(self):
+        """
+        Install amptrac.
+        """
+        # Bootstrap a new service environment
+        self.bootstrap()
+
+        postgres.createUser('amptrac')
+        postgres.grantRead('trac', 'amptrac')
+
+        with settings(user=self.serviceUser):
+            run('/bin/ln -nsf {}/start {}/start'.format(self.configDir, self.binDir))
+            self.update(_installDeps=True)
+            cron.install(self.serviceUser, '{}/crontab'.format(self.configDir))
+
+    def update(self, _installDeps=False):
+        """
+        Update config.
+        """
+        with settings(user=self.serviceUser):
+            git.branch('https://github.com/twisted-infra/amptrac-config', self.configDir)
+            amptracSource = 'git+https://github.com/twisted-infra/amptrac-server'
+            if _installDeps:
+                pip.install('{}'.format(amptracSource))
+            else:
+                pip.install('--no-deps --upgrade {}'.format(amptracSource))
+
+
+    def task_update(self):
+        """
+        Update config and restart.
+        """
+        self.update()
+        self.task_restart()
+
+
+addTasks(globals(), AmpTrac('amptrac').getTasks())

--- a/services/amptrac/start
+++ b/services/amptrac/start
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+~pypy/bin/twistd \
+    --logfile ~/log/twistd.log \
+    --pidfile ~/run/twistd.pid \
+    --rundir ~/run/ \
+    amptrac --postgres_db trac


### PR DESCRIPTION
Scope
=====

To simplify infra developlment we want to move the amptrac config from a git submodule to a normal folder.

Changes
=======

Removed the submodule and copied files from https://github.com/twisted-infra/amptrac-config

Update fabfile to install from local folder.

amptrac server is still installed using pip from https://github.com/twisted-infra/amptrac-server

amptrac-config README is pretty thin and it does not describe how it is supposed to be integrated with t-web or trac... I think that something is missing from the documentation as I was not able to apply the fabfile on vagrant vm


How to test
=========

amptrac config is broken as when I try to install it on the vagrant VM I get this

```
Fatal error: sudo() received nonzero return code 1 while executing!

Requested: /usr/bin/psql --no-align --no-readline --no-password --quiet --tuples-only  -c 'grant connect on database "trac" to "amptrac";'
Executed: sudo -S -p 'sudo password:'  -u "postgres"  /bin/bash -l -c "/usr/bin/psql --no-align --no-readline --no-password --quiet --tuples-only  -c 'grant connect on database \"trac\" to \"amptrac\";'"

================================ Standard error ================================

stdin: is not a tty
ERROR:  database "trac" does not exist
```

For now, I just want to move it into braid and then we can file a separate ticket and look at how to apply it on the vagrant VM.
