### PR TITLE
Vagrant + ansible provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,8 @@ There is `Vagrantfile` provided with braid, that will setup a staging sever.
 It uses the address `172.16.255.140`, and there is a braid config named `vagrant` that connects to it by default.
 
 ```shell
-# Get the required base OS image if you don't have it yet.
-vagrant box add precise64 http://files.vagrantup.com/precise64.box
 # Start the VM
 vagrant up
-# With ssh-aget add private key used by Vagrant
-ssh-add ~/.vagrant.d/insecure_private_key
+# Run the command
 fab config.vagrant COMMAND
-# Or without ssh-agent
-fab -i ~/.vagrant.d/insecure_private_key config.vagrant COMMAND
 ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ used, and a ssh connection as that user (with `settings(user='user')` or the lik
 Vagrant
 =======
 
-There is `Vagrantfile` provided with braid, that will setup a staging sever.
+> [Vagrant](https://www.vagrantup.com/) 1.7+ and [Ansible](http://docs.ansible.com/) 1.9+ is required to use the Vagrant image.
+
+There is `Vagrantfile` provided with braid, that will set up a staging server.
 It uses the address `172.16.255.140`, and there is a braid config named `vagrant` that connects to it by default.
 
 ```shell

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,27 +1,30 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-# Provision root account with the insecure Vagrant ssh key.
-$root_ssh_authorized_keys = <<ENDMARKER
-mkdir /root/.ssh
-chmod 700 /root/.ssh
-cp ~vagrant/.ssh/authorized_keys /root/.ssh
-ENDMARKER
-
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu/precise64"
-  config.vm.network :private_network, :ip => "172.16.255.140"
-  # Default folder synchronization is disables as the host is managed using
-  # fabric/braid.
+
   config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", disabled: true
+
+  config.vm.provider "virtualbox" do |v|
+      v.cpus = 1
+      v.memory = 2048
+  end
+
+  config.vm.define "dornkirk-staging" do |box|
+  # Every Vagrant virtual environment requires a box to build off of.
+    box.vm.box = "ubuntu/precise64"
+    box.vm.network :private_network, :ip => "172.16.255.140"
+    box.vm.network "forwarded_port", guest: 22, host: 2522
+  end
 
   # The only vagrant provisioning is to enable SSH access for root account.
   # After that provisioning is done using fabric/braid.
-  config.vm.provision "shell",
-    inline: $root_ssh_authorized_keys, privileged: true
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "provisioning/playbook.yml"
+    ansible.extra_vars = { ansible_ssh_user: 'vagrant'}
+  end
 
 end

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -1,0 +1,8 @@
+- hosts: dornkirk-staging
+  sudo: yes
+  tasks:
+    - name: Add vagrant key
+      action: authorized_key user=root key="{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+  roles:
+    - systemupdate
+    - requirements-debian

--- a/provisioning/roles/requirements-debian/tasks/main.yml
+++ b/provisioning/roles/requirements-debian/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Install locales
+  action: apt pkg=locales
+
+- name: Set up locale
+  action: locale_gen name=en_US.UTF-8
+
+- name: Install build requirements
+  action: apt pkg=build-essential,libffi-dev,libssl-dev,wget,git
+
+- name: Install Python
+  action: apt pkg=python-pip,python-virtualenv,python-subversion
+
+- name: Install other deps
+  action: apt pkg=sqlite3,equivs,enscript

--- a/provisioning/roles/systemupdate/tasks/main.yml
+++ b/provisioning/roles/systemupdate/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Update apt cache (Debian)
+  action: command apt-get update
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+- name: Upgrade apt packages (Debian)
+  action: command apt-get dist-upgrade -y
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
This changes the local Vagrant box to be provisioned by ansible. Eventually, more Ansible will replace the 'bootstrap' stuff and will make it easier to get repeatable infrastructure.

To test, just install Ansible, run `vagrant up`, and see that the Ansible stuff happens and everything is okay. Then run `fab config.vagrant base.bootstrap` to run the base machine bootstrapping, and everything should work.