### PR TITLE
Remove diffresource submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "services/diffresource"]
-	path = services/diffresource
-	url = https://github.com/twisted-infra/diffresource


### PR DESCRIPTION
We no longer use diffresource as we use GitHub code browser.

You will need to manually clean your .git/config file.