### PR TITLE
Install pyserial as base deps

### DIFF
--- a/services/buildbot/README
+++ b/services/buildbot/README
@@ -1,6 +1,7 @@
-This is the configuration for twistedmatrix.com's buildbot.
+This is the configuration for buildbot.twistedmatrix.com's buildmaster.
 
-It is adminstered using braid[1]. It is installed in `/srv/bb-master` as user bb-master.
+It is installed in `/srv/bb-master` as user `bb-master`.
+
 It uses the following directories:
 
 ~/config - This repository
@@ -29,6 +30,3 @@ updatePrivateData - Updates `~/private`.
 start - Start server.
 stop - Stop server.
 restart - Restart the server.
-
-[1] https://github.com/twisted-infra/braid
-

--- a/services/buildbot/master/twisted_factories.py
+++ b/services/buildbot/master/twisted_factories.py
@@ -34,6 +34,7 @@ BASE_DEPENDENCIES = [
     'zope.interface',
     'idna',
     'pyasn1',
+    'pyserial',
     'python-subunit',
 ]
 
@@ -45,7 +46,6 @@ CEXT_DEPENDENCIES = [
 # Dependencies that don't work on CPython 3.3+
 EXTRA_DEPENDENCIES = [
     'soappy',
-    'pyserial',
 ]
 
 # Dependencies for running on Windows


### PR DESCRIPTION
Scope
====

pyserial is supported on py2 and py3 on Linux/Unix

We have a few tests depending on pyserial.

install it as part of base deps

Changes
=======

move pyserial into BASE_DEPENDENCIES

cleanup buildbot/README . The code is no in braid so there is not much help to tell once again that this is braid.


How to test
==========

From this branch run

```
$ fab config.production buildbot.update
```

I have already applied the changes in production