### PR TITLE
Add hyper to run h2 tests.

### DIFF
--- a/services/buildbot/master/twisted_factories.py
+++ b/services/buildbot/master/twisted_factories.py
@@ -37,7 +37,7 @@ BASE_DEPENDENCIES = [
     'pyasn1',
     'pyserial',
     'python-subunit',
-    'hyper',
+    'h2',
 ]
 
 # Dependencies that don't work on PyPy

--- a/services/buildbot/master/twisted_factories.py
+++ b/services/buildbot/master/twisted_factories.py
@@ -37,6 +37,7 @@ BASE_DEPENDENCIES = [
     'pyasn1',
     'pyserial',
     'python-subunit',
+    'hyper',
 ]
 
 # Dependencies that don't work on PyPy


### PR DESCRIPTION
Scope
=====

This add the hyper as a dependency for all buillders so that we can run the future h2 tests.

Changes
=======

Just add any hyper version as @lukasa  told over IRC that this should be ok.

How to test
=========

From this branch run and check that new builds install hyper

```
$ fab config.production buildbot.update
```

I have already applied this branch on production.