### PR TITLE
Add dedicated environment for buildbot - buildmaster

### DIFF
--- a/braid/settings.py
+++ b/braid/settings.py
@@ -3,7 +3,6 @@ Default configuration settings.
 """
 
 dornkirk = 'dornkirk.twistedmatrix.com'
-
 vagrant_address = '172.16.255.140'
 
 ENVIRONMENTS = {
@@ -22,5 +21,13 @@ ENVIRONMENTS = {
         },
         'user': 'root',
         'installPrivateData': False,
+    },
+    'buildbot': {
+        'hosts': ['buildbot.twistedmatrix.com'],
+        'roledefs': {
+            'nameserver': ['buildbot.twistedmatrix.com'],
+        },
+        'user': 'root',
+        'installPrivateData': True,
     }
 }


### PR DESCRIPTION
Scope
=====

@glyph  wants to have the buildmaster on a dedicated VM.

See http://twistedmatrix.com/pipermail/twisted-python/2016-January/030114.html

Changes
=======

Create the new environment... which needs to be updated once the VM is created.


To do
=====

* create the VM
* document the VM - ip, hosting, who can manage it (destroy/recrecate), who has root access
* update the environment with new hostname/ipaddress/admin-account
* add dump/restore command to get sqlite3 file from an installations.

How to test
=========

Once the new VM is ready check that braid is able to star it.
```
fab config.buildbot base.bootstrap
fab config.buildbot services.buildbot
```

for now there are no dump/restore commands... not sure if we want this or we can do a manual copy :)
