### PR TITLE
Silly hack to fix dependency installation.

### DIFF
--- a/services/buildbot/master/twisted_factories.py
+++ b/services/buildbot/master/twisted_factories.py
@@ -38,7 +38,6 @@ BASE_DEPENDENCIES = [
     'pyserial',
     'python-subunit',
     'constantly',
-    'cryptography',
 ]
 
 # Dependencies that don't work on PyPy


### PR DESCRIPTION
#184 broke dependency installation on Windows, because cryptography lands up in the list twice. Since pyopenssl depends on cryptography, we don't actually need cryptography in the main list for now; this is a hack, but it seems the easiest way to fix this. (cryptography can go back in the main list once we're not pinning it to weird versions on different platforms)