### PR TITLE
Use GitHub for login

### DIFF
--- a/services/trac/fabfile.py
+++ b/services/trac/fabfile.py
@@ -68,6 +68,7 @@ class Trac(service.Service):
             self.venv.install('spambayes==1.1b2')
 
             self.venv.install('TracAccountManager==0.4.4')
+            self.venv.install('https://github.com/twisted-infra/trac-github/archive/master.tar.gz requests_oauthlib==0.6.1')
             self.venv.install('svn+https://trac-hacks.org/svn/defaultccplugin/tags/0.2/')
             self.venv.install('svn+https://svn.edgewall.org/repos/trac/plugins/1.0/spam-filter@14340')
 

--- a/services/trac/trac-env/conf/trac.ini
+++ b/services/trac/trac-env/conf/trac.ini
@@ -3,12 +3,6 @@
 [account-manager]
 account_changes_notify_addresses =
 authentication_url =
-force_passwd_change = true
-hash_method = HtDigestHashMethod
-htdigest_realm =
-htpasswd_file = ../htpasswd
-notify_actions =
-password_store = HtPasswdStore
 persistent_sessions = true
 
 [attachment]
@@ -43,19 +37,20 @@ acct_mgr.notification.accountchangenotificationadminpanel = enabled
 acct_mgr.pwhash.* = enabled
 acct_mgr.pwhash.htdigesthashmethod = enabled
 acct_mgr.pwhash.htpasswdhashmethod = enabled
-acct_mgr.register.emailverificationmodule = enable
-acct_mgr.register.registrationmodule = enabled
+acct_mgr.register.emailverificationmodule = disabled
+acct_mgr.register.registrationmodule = disabled
 acct_mgr.svnserve.* = enabled
 acct_mgr.svnserve.svnservepasswordstore = enabled
 acct_mgr.web_ui.* = enabled
 acct_mgr.web_ui.accountmodule = enabled
-acct_mgr.web_ui.loginmodule = enabled
+acct_mgr.web_ui.loginmodule = disabled
 defaultcc.admin.* = enabled
 defaultcc.main.* = enabled
 trac.settings.settingsmodule = disabled
 trac.versioncontrol.svn_prop.subversionmergepropertydiffrenderer = disabled
 trac.versioncontrol.svn_prop.subversionmergepropertyrenderer = disabled
-trac.web.auth.loginmodule = disabled
+trac.web.auth.LoginModule = disabled
+tracext.github.GitHubLoginModule = enabled
 tracspamfilter.adapters.* = enabled
 tracspamfilter.admin.* = enabled
 tracspamfilter.api.* = enabled
@@ -212,3 +207,8 @@ secure_cookies = False
 
 [wiki]
 ignore_missing_pages = true
+
+
+[github]
+client_id = caf865c9cb31e28f74a9
+client_secret = /srv/trac/secrets/secret.txt


### PR DESCRIPTION
How you can test this:

- set up your vagrant vm like usual (base.bootstrap, t-web.install, trac.install, t-web.start, trac.start)
- make some fake tls keys (t-web.makeTestTLSKeys, t-web.installTLSKeys)
- set `172.16.255.140 twistedmatrix.com` in your hosts file
- go to https://github.com/settings/developers , register a new application, put the client ID in `services/trac/trac-env/conf/trac.ini` right at the bottom -- the one in there right now is the prod ID
- ssh in to the vagrant vm, `sudo su trac; mkdir ~/secrets; cat $THEIDSECRET > ~/secrets/secret.txt`
- go to https://twistedmatrix.com/trac/ , click on the 'github login' button... you should be logged in!

Works on my instance :D