### PR TITLE
Remove log and patch links from ticket page. Update github link name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,6 @@ fab config.vagrant base.bootstrap
 # Run the braid commands using:
 fab config.vagrant COMMAND
 ```
+
+For example, after running `fab config.vagrant trac.update` you can access the
+Trac instance at http://172.16.255.140/trac

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ It uses the address `172.16.255.140`, and there is a braid config named `vagrant
 ```shell
 # Start the VM
 vagrant up
-# Run the command
+# In case you already have a VM, re-provision it using:
+vagrant provision
+# New VMs should be initialized using:
+fab config.vagrant base.bootstrap
+# Run the braid commands using:
 fab config.vagrant COMMAND
 ```

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -1,5 +1,5 @@
 - hosts: dornkirk-staging
-  sudo: yes
+  become: yes
   tasks:
     - name: Add vagrant key
       action: authorized_key user=root key="{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
@@ -8,7 +8,7 @@
     - requirements-debian
 
 - hosts: buildbot
-  sudo: yes
+  become: yes
   roles:
     - systemupdate
     - ssh

--- a/services/t-web/README
+++ b/services/t-web/README
@@ -1,6 +1,6 @@
 This is the configuration for twistedmatrix.com's web server
 
-It is adminstered using braid[1]. It is installed in `/srv/t-web` as user t-web.
+It is installed in `/srv/t-web` as user `t-web`.
 It uses the following directories
 
 ~/config - This repository.

--- a/services/trac/README.rst
+++ b/services/trac/README.rst
@@ -1,9 +1,16 @@
 Trac
 ====
 
-This is the configuration for twistedmatrix.com's trac installation.
+This is the configuration for twistedmatrix.com's Trac installation.
 
-It is adminstered using braid[1]. It is installed in ``/srv/trac`` as user trac.
+It requires that the `t-web` service to be started::
+
+    fab t-web.install
+    fab t-web.start
+
+It is installed in ``/srv/trac`` as user `trac`.
+
+Inside the `t-web` service, it is available at `http://server.name/trac/`
 
 It uses the following directories:
 

--- a/services/trac/README.rst
+++ b/services/trac/README.rst
@@ -31,16 +31,4 @@ A webhook from GitHub updates the repository at ``~/twisted.git`` and notifies t
 The GitHub webhook is configured at https://github.com/twisted/twisted/settings/hooks, with a payload URL of ``https://twistedmatrix.com/trac/github``.
 More information about how the post-commit hook works is available in the `trac-github readme <https://github.com/trac-hacks/trac-github#post-commit-hook>`_.
 
-The following fabric commands are available:
-
-- ``install`` - Create user and install configuration.
-- ``installTestData`` - Makes a blank database for basic testing.
-- ``getGithubMirror:<reponame>`` - Get ``twisted/<reponame>`` from GitHub and put it at ``~/twisted.git``. It will be automatically updated by Trac afterwards.
-- ``update`` - Updates the configuration and restarts the server.
-- ``upgrade`` - Upgrades the Trac database.
-- ``start`` - Start server.
-- ``stop`` - Stop server.
-- ``restart`` - Restart the server.
-- ``giveAdmin:<user>`` - Gives super admin to the mentioned Trac user.
-- ``dump:<dump-file>`` - Dump trac db and attachments
-- ``restore:<dump-file>`` - Restore trac db and attachments
+Use `fab -l` to check the available commands.

--- a/services/trac/fabfile.py
+++ b/services/trac/fabfile.py
@@ -44,7 +44,7 @@ class Trac(service.Service):
 
     def update(self):
         """
-        Update trac config.
+        Remove the current trac installation and reinstalls it.
         """
         with settings(user=self.serviceUser):
             self.venv.create()
@@ -68,7 +68,7 @@ class Trac(service.Service):
 
     def task_update(self):
         """
-        Update config and restart.
+        Stop, remove the current Trac installation, reinstalls it and start.
         """
         try:
             self.task_stop()
@@ -80,7 +80,8 @@ class Trac(service.Service):
 
     def task_upgrade(self):
         """
-        Run a Trac upgrade.
+        Remove the existing installation, re-install it and run a Trac
+        upgrade.
         """
         with settings(user=self.serviceUser):
             self.update()

--- a/services/trac/trac-env/templates/site.html
+++ b/services/trac/trac-env/templates/site.html
@@ -137,7 +137,8 @@
         <py:if test="ticket['branch']">
           <br/>
           (<a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch']}">branch-diff</a>,
-          <a href="https://codecov.io/gh/twisted/twisted/compare/trunk...${ticket['branch']}">coverage</a>,
+          <a href="https://codecov.io/gh/twisted/twisted/compare/trunk...${ticket['branch']}">diff-coverage</a>,
+          <a href="https://codecov.io/gh/twisted/twisted/branch/${ticket['branch']}">branch-coverage</a>,
           <a href="https://buildbot.twistedmatrix.com/boxes-supported?num_builds=2&branch=${ticket['branch']}">buildbot</a>,
         </py:if>
       </td>

--- a/services/trac/trac-env/templates/site.html
+++ b/services/trac/trac-env/templates/site.html
@@ -140,7 +140,7 @@
           <a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch']}">branch-diff</a>,
           <a href="https://codecov.io/gh/twisted/twisted/compare/trunk...${ticket['branch']}">diff-coverage</a>,
           <a href="https://codecov.io/gh/twisted/twisted/branch/${ticket['branch']}">branch-coverage</a>,
-          <a href="https://buildbot.twistedmatrix.com/boxes-supported?num_builds=2&branch=${ticket['branch']}">buildbot</a>,
+          <a href="https://buildbot.twistedmatrix.com/boxes-supported?num_builds=2&amp;&amp;branch=${ticket['branch']}">buildbot</a>,
           )
         </py:if>
       </td>

--- a/services/trac/trac-env/templates/site.html
+++ b/services/trac/trac-env/templates/site.html
@@ -136,10 +136,12 @@
         ${ticket['branch']}
         <py:if test="ticket['branch']">
           <br/>
-          (<a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch']}">branch-diff</a>,
+          (
+          <a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch']}">branch-diff</a>,
           <a href="https://codecov.io/gh/twisted/twisted/compare/trunk...${ticket['branch']}">diff-coverage</a>,
           <a href="https://codecov.io/gh/twisted/twisted/branch/${ticket['branch']}">branch-coverage</a>,
           <a href="https://buildbot.twistedmatrix.com/boxes-supported?num_builds=2&branch=${ticket['branch']}">buildbot</a>,
+          )
         </py:if>
       </td>
     </py:match>

--- a/services/trac/trac-env/templates/site.html
+++ b/services/trac/trac-env/templates/site.html
@@ -136,11 +136,9 @@
         ${ticket['branch']}
         <py:if test="ticket['branch']">
           <br/>
-          (<a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch']}">github</a>,
+          (<a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch']}">branch-diff</a>,
           <a href="https://codecov.io/gh/twisted/twisted/compare/trunk...${ticket['branch']}">coverage</a>,
-          <a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch']}.patch">patch</a>,
           <a href="https://buildbot.twistedmatrix.com/boxes-supported?branch=${ticket['branch']}">buildbot</a>,
-          <a href="/trac/log/${ticket['branch']}">log</a>)
         </py:if>
       </td>
     </py:match>

--- a/services/trac/trac-env/templates/site.html
+++ b/services/trac/trac-env/templates/site.html
@@ -138,7 +138,7 @@
           <br/>
           (<a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch']}">branch-diff</a>,
           <a href="https://codecov.io/gh/twisted/twisted/compare/trunk...${ticket['branch']}">coverage</a>,
-          <a href="https://buildbot.twistedmatrix.com/boxes-supported?branch=${ticket['branch']}">buildbot</a>,
+          <a href="https://buildbot.twistedmatrix.com/boxes-supported?num_builds=2&branch=${ticket['branch']}">buildbot</a>,
         </py:if>
       </td>
     </py:match>

--- a/services/trac/trac-env/templates/site.html
+++ b/services/trac/trac-env/templates/site.html
@@ -136,12 +136,10 @@
         ${ticket['branch']}
         <py:if test="ticket['branch']">
           <br/>
-          (
           <a href="https://github.com/twisted/twisted/compare/trunk...${ticket['branch']}">branch-diff</a>,
-          <a href="https://codecov.io/gh/twisted/twisted/compare/trunk...${ticket['branch']}">diff-coverage</a>,
-          <a href="https://codecov.io/gh/twisted/twisted/branch/${ticket['branch']}">branch-coverage</a>,
-          <a href="https://buildbot.twistedmatrix.com/boxes-supported?num_builds=2&amp;&amp;branch=${ticket['branch']}">buildbot</a>,
-          )
+          <a href="https://codecov.io/gh/twisted/twisted/compare/trunk...${ticket['branch']}">diff-cov</a>,
+          <a href="https://codecov.io/gh/twisted/twisted/branch/${ticket['branch']}">branch-cov</a>,
+          <a href="https://buildbot.twistedmatrix.com/boxes-supported?num_builds=2&amp;&amp;branch=${ticket['branch']}">buildbot</a>
         </py:if>
       </td>
     </py:match>


### PR DESCRIPTION
Scope
=====

This tries to clean the external links in a ticket page

```
(13.05.2016 08:20:30) The topic for #twisted-admin is: twisted infrastrucutre | https://github.com/twisted-infra
(10:17:17) adiroiban: hawkowl: hi. do we still need the 'patch' link in trac? I think that github link is enough :)
(10:17:34) adiroiban: and the 'log' link is broken...
(10:17:39) adiroiban: and not sure if we want it
(11:51:02) glyph: adiroiban: yup, kill 'em both
```

Changes
=======

See diff.

I have renamed the 'github' link to 'branch-diff' as I feel that the github link is not a good description.

As a drive by I tried to update the documentation based on my experience on trying to run trac in the VM.

As a drive-by I have updated the ansible rules as I got a warning that `become` is the new fancy term for sudo.

How to test
=========

In an ideal world this could be tested inside the vagrant vm.

I was not able to run trac in the vagrant VM as I got this error

```
Cannot find an implementation of the IRequestHandler interface named WikiModule. Please check that the Component is enabled or update the option [trac] default_handler in trac.ini.
```
braid has the same trac.ini config file as dornkirk...

and `fab config.vagrant trac.installTestData` is broken
