### PR TITLE
Send builder status to GitHub

### DIFF
--- a/services/buildbot/fabfile.py
+++ b/services/buildbot/fabfile.py
@@ -105,14 +105,14 @@ class Buildbot(service.Service):
                 )
 
             self.venv.install_twisted()
-            self.venv.install("virtualenv txacme")
+            self.venv.install("virtualenv txacme txgithub>=15.0.0")
 
             if _installDeps:
                 # sqlalchemy-migrate only works with a specific version of
                 # sqlalchemy.
                 buildbot_source = os.path.join(buildbotSource, 'master')
                 self.venv.install(
-                    'sqlalchemy==0.7.10 sqlalchemy-migrate==0.7.2 txgithub '
+                    'sqlalchemy==0.7.10 sqlalchemy-migrate==0.7.2 '
                     '{}'.format(
                         buildbot_source))
             else:

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -14,9 +14,11 @@ sys.path.insert(0, dirname(__file__))
 del expanduser, dirname, sys
 
 from buildbot.changes import filter
+from buildbot.process.properties import Interpolate
 from buildbot.schedulers.timed import Nightly
 from buildbot.schedulers import forcesched
 from buildbot.status import words, client, mail
+from buildbot.status.github import GitHubStatus
 from buildbot.status.web.auth import BasicAuth
 from buildbot.status.web.authz import Authz
 from buildbot.locks import SlaveLock
@@ -656,6 +658,15 @@ m = mail.MailNotifier(fromaddr="buildbot@twistedmatrix.com",
                       mode="problem",
                      )
 c['status'].append(m)
+
+c['status'].append(GitHubStatus(
+    token=private.github_status_token,
+    repoOwner='twisted',
+    repoName='twisted',
+    sha=Interpolate("%(prop:got_revision)s"),
+    startDescription='Buildbot test started.',
+    endDescription='Buildbot test done.',
+    ))
 
 
 c['projectName'] = "Twisted"

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -676,6 +676,9 @@ c['status'].append(GitHubStatus(
     token=private.github_status_token,
     repoOwner='twisted',
     repoName='twisted',
+    # When build are manually triggered from the builder page and only the
+    # branch is specified, `revision` is empty so we are looking at
+    # `got_revision`.
     sha=Interpolate("%(prop:got_revision)s"),
     startDescription='Buildbot test started.',
     endDescription='Buildbot test done.',

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -63,9 +63,8 @@ codecov_twisted_token = 'invalid'
 # For testing, get a Personal Access Token
 # https://github.com/settings/tokens
 #
-#
 # For production get a OAuth Token.
-# GitHub OAuth Application for Twisted Builbot Status is here:
+# GitHub OAuth Application for Twisted Buildbot Status is here:
 # https://github.com/organizations/twisted/settings/applications/373261
 #
 # If you disable the 2-way-auth you can get a OAuth token for this application
@@ -73,7 +72,7 @@ codecov_twisted_token = 'invalid'
 #
 # curl -u YOUR_USERNAME -d '{
 #     "scopes": ["repo:status"],
-#     "client_id": "YOUR-CLIEN"
+#     "client_id": "YOUR-CLIENT-ID"
 #     "client_secret": "SOME-SECRET"
 #    }' https://api.github.com/authorizations
 github_status_token = 'invalid-secret'

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -59,11 +59,17 @@ debugPassword = "cd3dad27_0f84b396"
 codecov_twisted_token = 'invalid'
 
 
+#
+# For testing, get a Personal Access Token
+# https://github.com/settings/tokens
+#
+#
+# For production get a OAuth Token.
 # GitHub OAuth Application for Builbot Status is here:
 # https://github.com/organizations/twisted/settings/applications/373261
 #
 # If you disable the 2-way-auth you can get a OAuth token for this application
-# by using this command
+# by using this command:
 #
 # curl -u YOUR_USERNAME -d '{
 #     "scopes": ["repo:status"],

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -58,6 +58,20 @@ debugPassword = "cd3dad27_0f84b396"
 
 codecov_twisted_token = 'invalid'
 
+
+# GitHub OAuth Application for Builbot Status is here:
+# https://github.com/organizations/twisted/settings/applications/373261
+#
+# If you disable the 2-way-auth you can get a OAuth token for this application
+# by using this command
+#
+# curl -u YOUR_USERNAME -d '{
+#     "scopes": ["repo:status"],
+#     "client_id": "YOUR-CLIEN"
+#     "client_secret": "SOME-SECRET"
+#    }' https://api.github.com/authorizations
+github_status_token = 'invalid-secret'
+
 # web status options
 # - default for testing deployments: port 8080 on localhost
 # - deployed version uses distrib_port at ~/webstatus.twistd-web-pb

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -65,7 +65,7 @@ codecov_twisted_token = 'invalid'
 #
 #
 # For production get a OAuth Token.
-# GitHub OAuth Application for Builbot Status is here:
+# GitHub OAuth Application for Twisted Builbot Status is here:
 # https://github.com/organizations/twisted/settings/applications/373261
 #
 # If you disable the 2-way-auth you can get a OAuth token for this application


### PR DESCRIPTION
Scope
=====

This add support for reporting build result status for all builds done by Buildbot  for fixing #147


Changes
=======

I have configured GitHub status reporting in the buildbot configuration.

I have created a dedicated OAuth app in GitHub for Buildbot status
 https://github.com/organizations/twisted/settings/applications/373261

I have set its logo to the Buildbot nut logo :) Feel free to suggest any other image

For testing, I got my own token... and before deploying in production I will update the private repo with the token generated for the dedicated OAuth app

How to test
=========

You can see it in action here

* For a PR  https://github.com/twisted/twisted/pull/212
* For a branch comparison https://github.com/twisted/twisted/compare/8494-codecov-config

Once this hit production we will see 28 build results from buildbot