### PR TITLE
[#202] Trigger builds on push via GitHub webhooks

### DIFF
--- a/services/buildbot/README
+++ b/services/buildbot/README
@@ -25,3 +25,13 @@ You can attach the testing slave which servers all builders by running::
 
     fab config.vagrant buildslave.start
 
+To trigger a wehbook in the Vagrant VM, get a payload from GitHub
+https://github.com/twisted/twisted/settings/hooks/8337490, save it to a local
+file and push it using curl:
+
+    curl -H "Content-Type: application/json" \
+        -H "X-GitHub-Event: push" \
+        -H "X-Hub-Signature: sha1=someting-or-ignored" \
+        -X POST \
+        -d @payload \
+        http://172.16.255.140:8080/change_hook/github

--- a/services/buildbot/fabfile.py
+++ b/services/buildbot/fabfile.py
@@ -66,7 +66,7 @@ class Buildbot(service.Service):
 
     def task_upgradeMaster(self):
         """
-        Upgrade the master.
+        Only upgrade the master database.
         """
         targetPath = os.path.join(self.configDir)
         with settings(user=self.serviceUser), cd(targetPath):
@@ -87,21 +87,20 @@ class Buildbot(service.Service):
             put(
                 os.path.dirname(__file__) + '/start', self.configDir,
                 mirror_local_mode=True)
-            put(
-                os.path.dirname(__file__) + '/master/*', self.configDir,
-                mirror_local_mode=True)
 
             buildbotSource = os.path.join(self.configDir, 'buildbot-source')
+            buildmasterSource = os.path.join(buildbotSource, 'master')
             # For now we are using a buildbot eight HEAD due to a bug in
             # 0.8.12
             # https://github.com/buildbot/buildbot/pull/1924
             # A forked branch is still used to control its version.
             # If changes are required to this branch it should use a name
             # other than `eight` to reduce confusion.
+            buildbotBranch = 'eight'
             git.branch(
                 url='https://github.com/twisted-infra/buildbot',
                 destination=buildbotSource,
-                branch='eight',
+                branch=buildbotBranch,
                 )
 
             self.venv.install_twisted()
@@ -110,14 +109,23 @@ class Buildbot(service.Service):
             if _installDeps:
                 # sqlalchemy-migrate only works with a specific version of
                 # sqlalchemy.
-                buildbot_source = os.path.join(buildbotSource, 'master')
                 self.venv.install(
                     'sqlalchemy==0.7.10 sqlalchemy-migrate==0.7.2 txgithub '
-                    '{}'.format(
-                        buildbot_source))
+                    '{}'.format(buildmasterSource))
             else:
-                self.venv.install('--no-deps {}'.format(
-                    os.path.join(buildbotSource, 'master')))
+                self.venv.install('--no-deps {}'.format(buildmasterSource))
+
+            self.updatefast()
+
+
+    def updatefast(self):
+        """
+        Update only some of the config.
+        """
+        with settings(user=self.serviceUser):
+            put(
+                os.path.dirname(__file__) + '/master/*', self.configDir,
+                mirror_local_mode=True)
 
             if env.get('installPrivateData'):
                 self.task_updatePrivateData()
@@ -134,23 +142,6 @@ class Buildbot(service.Service):
             # is functional.
             run('sed -i s/80/%s/g ~/config/buildbot.tac' % (redirector_port,))
 
-
-    def updatefast(self):
-        """
-        Update only some of the config.
-        """
-        with settings(user=self.serviceUser):
-            put(
-                os.path.dirname(__file__) + '/master/twisted_*',
-                self.configDir,
-                mirror_local_mode=True)
-            put(
-                os.path.dirname(__file__) + '/master/master.cfg',
-                self.configDir,
-                mirror_local_mode=True)
-
-            if env.get('installPrivateData'):
-                self.task_updatePrivateData()
 
     def task_update(self):
         """

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -29,6 +29,10 @@ del expanduser, dirname, sys
 from buildbot.changes import filter
 from buildbot.schedulers.timed import Nightly
 from buildbot.schedulers import forcesched
+from buildbot.schedulers.basic import (
+    AnyBranchScheduler,
+    SingleBranchScheduler,
+    )
 from buildbot.status import words, client, mail
 from buildbot.status.web.auth import BasicAuth
 from buildbot.status.web.authz import Authz
@@ -56,8 +60,7 @@ from twisted_factories import (
 )
 
 from txbuildbot.git import MergeForward, TwistedGit
-from txbuildbot.web import TwistedWebStatus
-from txbuildbot.scheduler import TwistedScheduler
+from txbuildbot.web import TwistedGitHubEventHandler, TwistedWebStatus
 
 BuildmasterConfig = c = {}
 
@@ -589,45 +592,87 @@ if 'vagrant-testing' in private.bot_info.keys():
 c['builders'] = builders
 
 
+def fileIsImportant(change):
+    """
+    Ignore branches which are changing the fun documetation.
+
+    It is expected that fun changes will not be committed together with other
+    changes.
+    """
+    for filename in change.files:
+        if not filename.startswith("docs/fun/"):
+            return 1
+    return 0
+
+
 # Now set up the schedulers. We do this after setting up c['builders']
 # so we can auto-generate the correct configuration from the builder
 # definitions.
 c['schedulers'] = [
-    TwistedScheduler(
+
+    # Trunk only branch scheduler.
+    SingleBranchScheduler(
         name="all",
         change_filter=filter.ChangeFilter(branch='trunk'),
-        builderNames=[b['name'] for b in builders if b['category'] in ('supported', 'unsupported')],
-        treeStableTimer=None),
+        builderNames=[
+            b['name'] for b in builders if b['category'] in ('supported', 'unsupported')],
+        fileIsImportant=fileIsImportant,
+        # The build is triggered almost right away, but there is a small
+        # delay to allow merging the changes.
+        # When a merge is done, we receive notifications for the merge commit
+        # for also for each commit which was merged.
+        treeStableTimer=5,
+        ),
+
+    # Any non-trunk branch triggering only the supported builders.
+    # In case there are multiple changes, we wait
+    AnyBranchScheduler(
+        name="branch-supported",
+        change_filter=filter.ChangeFilter(
+            branch_fn=lambda name: name != 'trunk'),
+        builderNames=[
+            b['name'] for b in builders if b['category'] == 'supported'],
+        fileIsImportant=fileIsImportant,
+        # As for trunk, we wait a bit so that we can aggregate multiple
+        # commits and only run the latest commit.
+        treeStableTimer=5,
+        ),
+
+    # Run the benchmark test suite every day.
     Nightly(
         name="Benchmarks",
         builderNames=[
             b['name'] for b in builders if b['category'] == 'benchmark'],
-        hour=6, minute=3, branch=None, onlyIfChanged=True),
-    ]
+        hour=6, minute=3, branch=None, onlyIfChanged=True,
+        ),
 
-c['schedulers'].extend([
     forcesched.ForceScheduler(
         name='force-supported',
         repository=forcesched.FixedParameter(name='repository', default=''),
         branch=forcesched.StringParameter(name='branch', default=''),
         project=forcesched.FixedParameter(name="project", default=""),
-	properties=[forcesched.StringParameter(name='test-case-name', label="test case", default='twisted')],
-        builderNames=[ b['name'] for b in builders if b['category'] == 'supported' ]),
+        properties=[forcesched.StringParameter(name='test-case-name', label="test case", default='twisted')],
+        builderNames=[ b['name'] for b in builders if b['category'] == 'supported'],
+        ),
+
     forcesched.ForceScheduler(
         name='force-unsupported',
         repository=forcesched.FixedParameter(name='repository', default=''),
         branch=forcesched.StringParameter(name='branch', default=''),
         project=forcesched.FixedParameter(name="project", default=""),
         properties=[forcesched.StringParameter(name='test-case-name', label="test case", default='twisted')],
-        builderNames=[ b['name'] for b in builders if b['category'] == 'unsupported' ]),
+        builderNames=[ b['name'] for b in builders if b['category'] == 'unsupported'],
+        ),
+
     forcesched.ForceScheduler(
         name='force-benchmark',
         repository=forcesched.FixedParameter(name='repository', default=''),
         branch=forcesched.StringParameter(name='branch', default=''),
         project=forcesched.FixedParameter(name="project", default=""),
         properties=[forcesched.StringParameter(name='test-case-name', label="test case", default='twisted')],
-        builderNames=[ b['name'] for b in builders if b['category'] == 'benchmark' ]),
-])
+        builderNames=[ b['name'] for b in builders if b['category'] == 'benchmark'],
+        ),
+    ]
 
 # configure other status things
 
@@ -654,7 +699,18 @@ authz = Authz(
 status = TwistedWebStatus(
     authz=authz,
     public_html=sibpath(__file__, 'public_html'),
-    change_hook_dialects={'github': {}},
+    change_hook_dialects={
+        # Will create a resource available at BUILDBOT_URL/change_hook/github
+        'github': {
+            'secret': private.github_hook_secret,
+            # When running in Vagrant VM you might want to set it to `False`
+            # to allow unsigned events. But you can leave it to `True` in the
+            # case in which can get a payload from GitHut at
+            # https://github.com/twisted/twisted/settings/hooks/8337490
+            'strict': False,
+            'class': TwistedGitHubEventHandler,
+            },
+        },
     jinja_loaders=[jinja2.FileSystemLoader(sibpath(__file__, 'templates'))],
     **private.webOptions)
 c['status'].append(status)

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -702,11 +702,7 @@ status = TwistedWebStatus(
         # Will create a resource available at BUILDBOT_URL/change_hook/github
         'github': {
             'secret': private.github_hook_secret,
-            # When running in Vagrant VM you might want to set it to `False`
-            # to allow unsigned events. But you can leave it to `True` in the
-            # case in which can get a payload from GitHut at
-            # https://github.com/twisted/twisted/settings/hooks/8337490
-            'strict': False,
+            'strict': private.github_hook_strict,
             'class': TwistedGitHubEventHandler,
             },
         },

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -625,7 +625,6 @@ c['schedulers'] = [
         ),
 
     # Any non-trunk branch triggering only the supported builders.
-    # In case there are multiple changes, we wait
     AnyBranchScheduler(
         name="branch-supported",
         change_filter=filter.ChangeFilter(

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -60,6 +60,9 @@ codecov_twisted_token = 'invalid'
 
 # Secret used to sign hooks payload received from GitHub
 github_hook_secret = None
+# When running in Vagrant VM you might not have access to the secret.
+# This is why the signature is disabled for testing.
+github_hook_strict = False
 
 # web status options
 # - default for testing deployments: port 8080 on localhost

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -58,6 +58,9 @@ debugPassword = "cd3dad27_0f84b396"
 
 codecov_twisted_token = 'invalid'
 
+# Secret used to sign hooks payload received from GitHub
+github_hook_secret = None
+
 # web status options
 # - default for testing deployments: port 8080 on localhost
 # - deployed version uses distrib_port at ~/webstatus.twistd-web-pb

--- a/services/buildbot/master/txbuildbot/scheduler.py
+++ b/services/buildbot/master/txbuildbot/scheduler.py
@@ -1,9 +1,0 @@
-from buildbot.schedulers.basic import SingleBranchScheduler
-
-class TwistedScheduler(SingleBranchScheduler):
-    @staticmethod
-    def fileIsImportant(change):
-        for filename in change.files:
-            if not filename.startswith("docs/fun/"):
-                return 1
-        return 0

--- a/services/buildbot/master/txbuildbot/web.py
+++ b/services/buildbot/master/txbuildbot/web.py
@@ -1,6 +1,7 @@
 import time
 
 from buildbot.status.web.base import HtmlResource, map_branches, build_get_class, path_to_builder, path_to_build
+from buildbot.status.web.hooks.github import GitHubEventHandler
 from buildbot.status.builder import SUCCESS, WARNINGS, FAILURE, SKIPPED, EXCEPTION, RETRY
 from buildbot.status import html
 from buildbot.util import formatInterval
@@ -153,3 +154,20 @@ class TwistedWebStatus(html.WebStatus):
         # http://trac.buildbot.net/ticket/2268
         self.putChild("grid", Redirect("boxes-supported"))
         self.putChild("tgrid", Redirect("boxes-supported"))
+
+
+
+class TwistedGitHubEventHandler(GitHubEventHandler):
+    """
+    Custom handling of GitHub hooks.
+    """
+
+    def handle_pull_request(self, payload):
+        """
+        For now triggering builds on PR is disabled.
+
+        The hook should not be called for non-push events, but this is here
+        as a fallback and to document that for now we don't want to execute
+        build on PRs as we don't trust the external contributors.
+        """
+        return [], 'git'


### PR DESCRIPTION
Scope
======

This add support for triggering builds when branches are pushed.

This tries to fix #202

Change
======

For now, the secret / payload authentication  is not enabled as I don't have write access to the private repo. The variables for supporting authentication are defined.

For now only the supported builds are auto-triggered for non-trunk branches. 

txbuildbot/scheduler.py was removed as it was only used for fileIsImportant and this  can be configured with a simple callable.

TwistedGitHubEventHandler was created only to prevent accidental hooks on PR.
If we want to enable building on PR, we should create a new issue in brain and test this scenario.

The production builders uses a secret token and it always asks for signed payloads.

For Vagrant VM the sample private files come without requiring a token

As a drive by, I have updated the `updatefast()` method to reduce code duplication.

How to test
=========

Testing in Vagrant VM
-----------------------------

Create or get some payload from https://github.com/twisted/twisted/settings/hooks/8337490

Check the readme for help in delivering the hooks.

Deliver a payload for trunk and non-trunk and observer how the changes are triggred.

You can observe them by looking at a builder http://172.16.255.140:8080/builders/check-manifest

You should observer that multiple builds are delayed for 5 seconds and then only the last build is triggered.

Once a build is triggred, look at the build property and observer the `scheduler` field. It should be `trunk` for trunk commits and `branch-supported` for non-trunk builds.

Also trunk commits will trigger all builders, including the ones which are not supported.

Testing in production
---------------------------

This branch can be applied to production.
For an existing PR or an existing or new branch push a commit. Observer that the supported builds are triggered and that the status is updated.