### PR TITLE
Add Windows slave hosted by Rackspace

### DIFF
--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -254,7 +254,7 @@ builders.append({
 #
 builders.append({
     'name': 'win-64-py2.7',
-    'builddir': 'win-64-py2.7-select',
+    'slavenames': ['rax-win2012r2-1'],
     'factory': TwistedVirtualenvReactorsBuildFactory(
         git_update, RemovePYCs=Win32RemovePYCs,
         dependencies=(BASE_DEPENDENCIES + CEXT_DEPENDENCIES +

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -291,7 +291,7 @@ builders.append({
         uncleanWarnings=True,
         arch="win-amd64",
         pyVersion="2.7"),
-    'category': 'supported',
+    'category': 'unsupported',
     })
 
 

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -83,8 +83,6 @@ ubuntu16_04_slaves = ['rax-ubuntu1604-%d' % (i,) for i in range(1,4)]
 
 allpy27_slaves = fedora22_slaves + fedora23_slaves + ubuntu12_04_slaves + ubuntu16_04_slaves
 
-win_slaves = ['bot-glyph-6', 'rax-win2012r2-1']
-
 # These builders run some heavy builders (pypy, jython) so only run one at a
 # time.
 for slave in ubuntu16_04_slaves:
@@ -253,10 +251,10 @@ builders.append({
     'category': 'unsupported'})
 
 #
-# Windows
+# Windows 2012R2 only available on X86_64.
 #
 builders.append({
-    'name': 'win-64-py2.7',
+    'name': 'win2012r2-py2.7',
     'slavenames': ['rax-win2012r2-1'],
     'factory': TwistedVirtualenvReactorsBuildFactory(
         git_update, RemovePYCs=Win32RemovePYCs,
@@ -272,7 +270,7 @@ builders.append({
 
 
 builders.append({
-    'name': 'win-64-py2.7-coverage',
+    'name': 'win2012r2-py2.7-coverage',
     'slavenames': ['rax-win2012r2-1'],
     'factory': TwistedCoveragePyFactory(
         source=git_update, RemovePYCs=Win32RemovePYCs,
@@ -285,17 +283,6 @@ builders.append({
     'category': 'unsupported',
     })
 
-
-builders.append({
-    'name': "win-64-py2.7-msi",
-    'slavenames': ['rax-win2012r2-1'],
-    'factory': TwistedBdistFactory(
-        git_update,
-        uncleanWarnings=True,
-        arch="win-amd64",
-        pyVersion="2.7"),
-    'category': 'unsupported',
-    })
 
 
 #

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -80,6 +80,8 @@ ubuntu16_04_slaves = ['rax-ubuntu1604-%d' % (i,) for i in range(1,4)]
 
 allpy27_slaves = fedora22_slaves + fedora23_slaves + ubuntu12_04_slaves + ubuntu16_04_slaves
 
+win_slaves = ['bot-glyph-6', 'rax-win2012r2-1']
+
 # These builders run some heavy builders (pypy, jython) so only run one at a
 # time.
 for slave in ubuntu16_04_slaves:
@@ -246,6 +248,51 @@ builders.append({
         trial="./admin/run-python3-tests", tests='',
         dependencies=BASE_DEPENDENCIES + WINDOWS_DEPENDENCIES),
     'category': 'unsupported'})
+
+#
+# Windows
+#
+builders.append({
+    'name': 'win-64-py2.7',
+    'builddir': 'win-64-py2.7-select',
+    'factory': TwistedVirtualenvReactorsBuildFactory(
+        git_update, RemovePYCs=Win32RemovePYCs,
+        dependencies=(BASE_DEPENDENCIES + CEXT_DEPENDENCIES +
+                      EXTRA_DEPENDENCIES + WINDOWS_DEPENDENCIES),
+        python="C:\\Python27\\python.exe",
+        reactors=["select", "iocp"],
+        platform="windows",
+        uncleanWarnings=True,
+        ),
+    'category': 'unsupported',
+    })
+
+
+builders.append({
+    'name': 'win-64-py2.7-coverage',
+    'slavenames': ['rax-win2012r2-1'],
+    'factory': TwistedCoveragePyFactory(
+        source=git_update, RemovePYCs=Win32RemovePYCs,
+        dependencies=(BASE_DEPENDENCIES + CEXT_DEPENDENCIES +
+                      EXTRA_DEPENDENCIES + WINDOWS_DEPENDENCIES),
+        python="C:\\Python27\\python.exe", platform="windows",
+        buildID="windows64py27",
+        uncleanWarnings=True,
+        ),
+    'category': 'unsupported',
+    })
+
+
+builders.append({
+    'name': "win-64-py2.7-msi",
+    'slavenames': ['rax-win2012r2-1'],
+    'factory': TwistedBdistFactory(
+        git_update,
+        uncleanWarnings=True,
+        arch="win-amd64",
+        pyVersion="2.7"),
+    'category': 'supported',
+    })
 
 
 #

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -33,6 +33,7 @@ slaves = [
     "rax-ubuntu1604-3",
     "rax-debian8-1",
     "rax-debian8-2",
+    "rax-win2012r2-1",
 
     "github",
 ]


### PR DESCRIPTION
Scope
=====

In this way it should be easier to allow people to access it for maintenance

I saw that we are using only about $700 of rax invoice.

The windows slave was quite busy sometimes so a second slave should help

Changes
=======

I have created the smallest win2012r2 windows vm on RAX

The private repo was already pushed.

I am documenting the steps required to have a windows slave here https://twistedmatrix.com/trac/wiki/ContinuousIntegration/Buildslaves#BuildslaveonWindows

For now the new slaves are in the unsuported category as I did not managed to start buildslave a a service. 

I can start it in debug mode... but when I use the Windows service tool, it fails to start

The builddir option is no longer used as I think that it is automatically created by buildslave based on the builder name


To do
====

* Start buildslave as a service


How to test
=========

Changes are deployed in production

https://buildbot.twistedmatrix.com/builders/win-64-py2.7

https://buildbot.twistedmatrix.com/builders/win-64-py2.7-coverage
