### PR TITLE
Disable use_committer_id

### DIFF
--- a/services/trac/trac-env/conf/trac.ini
+++ b/services/trac/trac-env/conf/trac.ini
@@ -215,3 +215,6 @@ secure_cookies = False
 
 [wiki]
 ignore_missing_pages = true
+
+[git]
+use_committer_id = disabled


### PR DESCRIPTION
Fixes the issue where GitHub would get points in highscores

https://trac.edgewall.org/wiki/TracIni#git-section

@Hawkowl is awesome