### PR TITLE
Create tox / venv builder for all builders

### DIFF
--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -174,21 +174,26 @@ builders.append({
 
 
 builders.append({
-    'name': 'windows7-64-py2.7-nocov-alldeps',
+    'name': 'windows7-64-py2.7-alldeps-nocov',
     'slavenames': ['bot-glyph-6'],
     'factory': TwistedToxBuildFactory(
         git_update,
+        python='c:\\python27\\python.exe',
+        platform='windows',
         toxEnv='py27-alldeps-nocov-windows',
         reactors=['select', 'iocp'],
     ),
     'category': 'unsupported',
 })
 builders.append({
-    'name': 'windows7-64-py2.7-withcov-alldeps',
+    'name': 'windows7-64-py2.7-alldeps-withcov',
     'slavenames': ['bot-glyph-6'],
     'factory': TwistedToxBuildFactory(
         git_update,
+        python='c:\\python27\\python.exe',
+        platform='windows',
         toxEnv='py27-alldeps-withcov-windows,codecov-publish',
+        env={'CODECOV_TOKEN': private.codecov_twisted_token},
     ),
     'category': 'unsupported',
 })
@@ -197,6 +202,8 @@ builders.append({
     'slavenames': ['bot-glyph-6'],
     'factory': TwistedToxDistPublishFactory(
         git_update,
+        python='c:\\python27\\python.exe',
+        platform='windows',
         toxEnv='py27-wheel',
     ),
     'category': 'unsupported',
@@ -296,6 +303,7 @@ builders.append({
     'factory': TwistedToxBuildFactory(
         git_update,
         toxEnv='py27-nodeps-withcov-posix,codecov-publish',
+        env={'CODECOV_TOKEN': private.codecov_twisted_token},
         ),
     'category': 'unsupported',
     })

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -58,8 +58,6 @@ for slave in slaves:
 # Password for pb debug port
 debugPassword = "cd3dad27_0f84b396"
 
-codecov_twisted_token = 'invalid'
-
 #
 # GitHub Commit Status Update
 #
@@ -88,6 +86,12 @@ github_hook_secret = None
 # When running in Vagrant VM you might not have access to the secret.
 # This is why the signature is disabled for testing.
 github_hook_strict = False
+
+
+#
+# Codecov.io
+#
+codecov_twisted_token = 'invalid'
 
 # web status options
 # - default for testing deployments: port 8080 on localhost

--- a/services/buildbot/master/twisted_factories.py
+++ b/services/buildbot/master/twisted_factories.py
@@ -370,7 +370,8 @@ class ToxBuildFactoryAbstract(BuildFactory):
 
         BuildFactory.__init__(self, source)
 
-        self._tests = [WithProperties("%(test-case-name:~)s")]
+        # Use the test-case-name property or fallback to 'twisted'.
+        self._tests = [WithProperties("%(test-case-name:~twisted)s")]
 
         assert platform in ["unix", "windows"]
 

--- a/services/buildbot/master/twisted_factories.py
+++ b/services/buildbot/master/twisted_factories.py
@@ -352,21 +352,25 @@ class Win32RemovePYCs(ShellCommand):
 
 
 
-class TwistedToxBuildFactory(BuildFactory):
+class ToxBuildFactoryAbstract(BuildFactory):
     """
-    A build factor for running the tests in a virtual environment which is set
-    up using tox.
+    A build factor for running the things in a virtual environment which
+    is set up using tox.
     """
 
     workdir = "Twisted"
 
-    def __init__(self, source, toxEnv, reactors=["default"],
-                 allowSystemPackages=False, platform="unix", python="python"):
+    def __init__(self, source, toxEnv,
+        reactors=["default"],
+        allowSystemPackages=False,
+        platform="unix",
+        python="python",
+        env=None,
+            ):
 
         BuildFactory.__init__(self, source)
 
-        tests = [WithProperties("%(test-case-name:~)s")]
-        tests = []
+        self._tests = [WithProperties("%(test-case-name:~)s")]
 
         assert platform in ["unix", "windows"]
 
@@ -376,6 +380,13 @@ class TwistedToxBuildFactory(BuildFactory):
         elif platform == "windows":
             self._path = ntpath
 
+        self._toxEnv = toxEnv
+        self._env = env
+        self._reactors = reactors
+        self._allowSystemPackages = allowSystemPackages
+
+        # Workaround for virtualenv --clear issue.
+        # https://github.com/pypa/virtualenv/issues/929
         self.addStep(
             shell.ShellCommand,
             description="clearing virtualenv".split(" "),
@@ -394,14 +405,8 @@ class TwistedToxBuildFactory(BuildFactory):
             command=["python", "-m", "pip", "install", "tox", "virtualenv"]
         )
 
-        for reactor in reactors:
-            self.addVirtualEnvStep(TrialTox,
-                                   tests=tests,
-                                   allowSystemPackages=allowSystemPackages,
-                                   reactor=reactor,
-                                   toxEnv=toxEnv)
+        self._addRunSteps()
 
-        self._addAfterRunSteps()
 
     @property
     def _virtualEnvBin(self):
@@ -435,16 +440,44 @@ class TwistedToxBuildFactory(BuildFactory):
         else:
             pathsep = ":"
 
-        env['PATH'] = pathsep.join([self._virtualEnvBin, path, '${PATH}'])
+        env['PATH'] = pathsep.join([
+            self._virtualEnvBin,
+            self._path.join(self._virtualEnvPath, 'lib'),
+            path,
+            '${PATH}',
+            ])
         kwargs['env'] = env
         self.addStep(step, **kwargs)
 
 
-    def _addAfterRunSteps(self):
+    def _addRunSteps(self):
         """
-        To be overwritten by subclasses for adding custom steps after the
-        tox environments are done.
+        To be overwritten by subclasses for adding custom steps for
+        running the tox environment.
         """
+        raise NotImplementedError('_addRunSteps not implemented.')
+
+
+
+class TwistedToxBuildFactory(ToxBuildFactoryAbstract):
+    """
+    A build factor for running the tests in a virtual environment which is set
+    up using tox.
+    """
+
+    def _addRunSteps(self):
+        """
+        See: ToxBuildFactoryBase
+        """
+        for reactor in self._reactors:
+            self.addVirtualEnvStep(
+                TrialTox,
+                tests=self._tests,
+                allowSystemPackages=self._allowSystemPackages,
+                reactor=reactor,
+                toxEnv=self._toxEnv,
+                _env=self._env,
+                )
 
 
 
@@ -631,16 +664,23 @@ class TwistedBdistFactory(TwistedBaseFactory):
 
 
 
-class TwistedToxDistPublishFactory(TwistedToxBuildFactory):
+class TwistedToxDistPublishFactory(ToxBuildFactoryAbstract):
     """
     Run a tox environment and then upload all the files from the dist folder.
     """
     uploadBase = 'build_products/'
 
-    def _addAfterRunSteps(self):
+    def _addRunSteps(self):
         """
-        See: TwistedToxBuildFactory.
+        See: ToxBuildFactoryAbstract.
         """
+        self.addVirtualEnvStep(
+            shell.ShellCommand,
+            description='run step',
+            command=[
+                'python', '-m', 'tox', '-r', '-e', self._toxEnv]
+        )
+
         self.addStep(
             transfer.DirectoryUpload,
             name='upload-whell',

--- a/services/buildbot/master/twisted_steps.py
+++ b/services/buildbot/master/twisted_steps.py
@@ -123,7 +123,7 @@ class TrialTox(ShellCommand):
     haltOnFailure = True
 
     def __init__(self, toxEnv, reactor, tests=[], commandNumber=0,
-                 allowSystemPackages=False, _env={}, **kwargs):
+                 allowSystemPackages=False, _env=None, **kwargs):
 
         ShellCommand.__init__(self, **kwargs)
 
@@ -143,6 +143,8 @@ class TrialTox(ShellCommand):
         self.descriptionDone = ["tests"]
 
         self.addLogObserver('stdio', TrialTestCaseCounter())
+        if _env is None:
+            _env = {}
         self._env = _env
 
 


### PR DESCRIPTION
This requires Twisted updates https://twistedmatrix.com/trac/ticket/8544 so that we have tox env for everything

This creates tox/venv builders for nomodules and bdist ... and windows builders 

After this merged, #220 should be easy to fix

windows builders are stuck at cleaning/recreating the venv