### PR TITLE
[#244] Update Ubuntu version for Vagrant VM.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,10 +4,10 @@
 VAGRANTFILE_API_VERSION = "2"
 
 
-# Provision root account by copying the ssh key from the default vagrant user.    
+# Provision root account by copying the ssh key from the default user.    
 $root_ssh_authorized_keys = <<ENDMARKER   
 mkdir -p /root/.ssh    
-cp /home/vagrant/.ssh/authorized_keys /root/.ssh  
+cp /home/ubuntu/.ssh/authorized_keys /root/.ssh
 chmod -R 700 /root/.ssh    
 ENDMARKER
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.define "dornkirk-staging" do |box|
   # Every Vagrant virtual environment requires a box to build off of.
-    box.vm.box = "ubuntu/precise64"
+    box.vm.box = "ubuntu/xenial64"
     box.vm.network :private_network, :ip => "172.16.255.140"
   end
 

--- a/braid/base.py
+++ b/braid/base.py
@@ -28,7 +28,7 @@ def bootstrap():
     # libssl-dev is needed for installing pyOpenSSL for PyPy.
     package.install(['libssl-dev', 'libffi-dev'])
 
-    package.install(['python2.7', 'python2.7-dev', 'python-virtualenv'])
+    package.install(['python2.7', 'python2.7-dev'])
     # gcc and svn is needed for 'pip install'
     package.install(['gcc', 'subversion'])
     # For trac

--- a/braid/pip.py
+++ b/braid/pip.py
@@ -1,4 +1,4 @@
-from fabric.api import run, cd, settings, sudo
+from fabric.api import run, cd, settings, sudo, task
 from fabric.contrib import files
 
 from os import path
@@ -9,6 +9,7 @@ getPipDirectory = "/opt/pip"
 getPipLocation = path.join(getPipDirectory, "get-pip.py")
 
 
+@task
 def ensureGetPip(target=getPipDirectory, update=False):
     """
     Ensure we have C{get-pip.py} available in our expected location.
@@ -16,7 +17,7 @@ def ensureGetPip(target=getPipDirectory, update=False):
     if update or not files.exists(getPipLocation):
         sudo("mkdir -p {}".format(getPipDirectory))
         with cd(getPipDirectory):
-            sudo('/usr/bin/wget -O {}'.format(getPipLocation, pipURL))
+            sudo('/usr/bin/wget -O {} {}'.format(getPipLocation, pipURL))
         sudo('chmod a+r {}'.format(getPipLocation))
 
 

--- a/braid/pip.py
+++ b/braid/pip.py
@@ -1,23 +1,39 @@
-from fabric.api import run, cd, sudo
+from fabric.api import run, cd, settings, sudo
+from fabric.contrib import files
 
 from os import path
 
-from braid import info
-
 pipURL = 'https://bootstrap.pypa.io/get-pip.py'
 
+getPipDirectory = "/opt/pip"
+getPipLocation = path.join(getPipDirectory, "get-pip.py")
 
-def install(python):
 
-    with cd('/tmp'):
-        sudo('/usr/bin/wget -nc {}'.format(pipURL))
+def ensureGetPip(target=getPipDirectory, update=False):
+    """
+    Ensure we have C{get-pip.py} available in our expected location.
+    """
+    if update or not files.exists(getPipLocation):
+        sudo("mkdir -p {}".format(getPipDirectory))
+        with cd(getPipDirectory):
+            sudo('/usr/bin/wget -O {}'.format(getPipLocation, pipURL))
+        sudo('chmod a+r {}'.format(getPipLocation))
 
-    sudo("{python} {pipURL}".format(
-        python=python,
-        pipURL=path.join('/tmp/', path.basename(pipURL))))
 
-    # See https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
-    sudo("{} -m pip install -U ndg-httpsclient".format(python))
+def bootstrap(user, python, updateDependencies=False):
+    """
+    Bootstrap pip and virtualenv.
+    """
+    ensureGetPip(update=updateDependencies)
 
-    # Ensure we have the latest pip, virtualenv, setuptools, and wheel.
-    sudo("{} -m pip install -U pip virtualenv setuptools wheel".format(python))
+    with settings(user=user):
+        run("{python} {getPipLocation} --user".format(
+            python=python,
+            getPipLocation=getPipLocation))
+
+        # See https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
+        run("{} -m pip install --user -U ndg-httpsclient".format(python))
+
+        # Ensure we have the latest pip, virtualenv, setuptools, and wheel.
+        run("{} -m pip install --user -U"
+            " pip virtualenv setuptools wheel".format(python))

--- a/braid/postgres.py
+++ b/braid/postgres.py
@@ -4,10 +4,24 @@ from pipes import quote
 
 
 def install():
-    try:
-        package.install(['postgresql-9.1', 'postgresql-server-dev-9.1'])
-    except:
-        package.install(['postgresql-9.3', 'postgresql-server-dev-9.3'])
+    # TODO: what are the names of these packages on each platform and
+    # release?  There ought to be a table.
+    candidates = [
+        ('', '-all'),
+        ['-9.1'] * 2,
+        ['-9.3'] * 2,
+    ]
+    for server, dev in candidates:
+        try:
+            package.install(['postgresql{}'.format(server),
+                             'postgresql-server-dev{}'.format(dev)])
+        except:
+            continue
+        else:
+            break
+    else:
+        raise RuntimeError("Could not install any postgresql")
+
 
 
 def _runQuery(query, database=None):

--- a/braid/pypy.py
+++ b/braid/pypy.py
@@ -5,15 +5,15 @@ from fabric.api import cd, task, sudo, abort
 from braid import info
 from braid.utils import fails
 
-pypyVersion = "5.1.0"
+pypyVersion = "v5.9.0"
 
 pypyURLs = {
-    'x86_64': 'https://bitbucket.org/pypy/pypy/downloads/pypy-{version}-linux64.tar.bz2',
-    'x86': 'https://bitbucket.org/pypy/pypy/downloads/pypy-{version}-linux.tar.bz2',
+    'x86_64': 'https://bitbucket.org/pypy/pypy/downloads/pypy2-{version}-linux64.tar.bz2',
+    'x86': 'https://bitbucket.org/pypy/pypy/downloads/pypy2-{version}-linux.tar.bz2',
     }
 pypyDirs = {
-    'x86_64': '/opt/pypy-{version}-linux64',
-    'x86': '/opt/pypy-{version}-linux',
+    'x86_64': '/opt/pypy2-{version}-linux64',
+    'x86': '/opt/pypy2-{version}-linux',
     }
 
 @task

--- a/braid/service.py
+++ b/braid/service.py
@@ -3,7 +3,7 @@ from fabric.api import sudo, run
 
 def _service(action, service, useSudo=True):
     cmd = sudo if useSudo else run
-    cmd('/usr/bin/service {} {}'.format(service, action))
+    cmd('/usr/sbin/service {} {}'.format(service, action))
 
 
 def start(service, useSudo=True):

--- a/braid/settings.py
+++ b/braid/settings.py
@@ -36,6 +36,8 @@ ENVIRONMENTS = {
             'buildbot': [vagrant_address],
         },
         'user': 'root',
+        'key_filename': (
+            '.vagrant/machines/dornkirk-staging/virtualbox/private_key'),
         'installPrivateData': False,
     }
 }

--- a/braid/twisted/service.py
+++ b/braid/twisted/service.py
@@ -2,7 +2,7 @@ from cStringIO import StringIO
 
 from fabric.api import settings, run, put
 
-from braid import tasks, users, venv
+from braid import tasks, pip, users, venv
 
 from twisted.python.filepath import FilePath
 
@@ -49,12 +49,13 @@ class Service(tasks.Service):
         readmeContext['tasks'] = '\n'.join(tasks)
         return readmeFile.getContent().format(**readmeContext)
 
-    def bootstrap(self, venv_site_packages=False):
+    def bootstrap(self, venv_site_packages=False, updateDependencies=False):
         # Create the user only if it does not already exist
         users.createService(self.serviceUser)
+        pip.bootstrap(self.serviceUser, self.venv.sourceInterpreter,
+                      updateDependencies=updateDependencies)
 
         with settings(user=self.serviceUser):
-
             # Create a virtualenv in the service user's folder
             # It'll be a PyPy venv by default, unless self.python is changed
             self.venv.create(site_packages=venv_site_packages)

--- a/braid/twisted/service.py
+++ b/braid/twisted/service.py
@@ -52,7 +52,7 @@ class Service(tasks.Service):
     def bootstrap(self, venv_site_packages=False, updateDependencies=False):
         # Create the user only if it does not already exist
         users.createService(self.serviceUser)
-        pip.bootstrap(self.serviceUser, self.venv.sourceInterpreter,
+        pip.bootstrap(self.serviceUser, self.venv.BOOTSTRAP_PYTHON,
                       updateDependencies=updateDependencies)
 
         with settings(user=self.serviceUser):

--- a/braid/venv.py
+++ b/braid/venv.py
@@ -3,6 +3,7 @@ from os import path
 
 
 class VirtualEnvironment(object):
+    BOOTSTRAP_PYTHON = 'python2'
 
     def __init__(self, user, location="~/virtualenv", python="python2.7"):
 
@@ -17,19 +18,14 @@ class VirtualEnvironment(object):
         self._user = user
 
 
-    @property
-    def sourceInterpreter(self):
-        return self._python
-
-
     def create(self, site_packages=False):
         """
         Create the virtualenv. This uses "/usr/bin/env python2"'s virtualenv
         module.
         """
         with settings(user=self._user):
-            run(("/usr/bin/env python2 -m virtualenv --clear "
-                 "-p {} {} {}").format(self._python, self._location,
+            run(("/usr/bin/env {} -m virtualenv --clear "
+                 "-p {} {} {}").format(self.BOOTSTRAP_PYTHON, self._python, self._location,
                                        '--system-site-packages' if site_packages else ''))
 
         # https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning

--- a/braid/venv.py
+++ b/braid/venv.py
@@ -17,6 +17,11 @@ class VirtualEnvironment(object):
         self._user = user
 
 
+    @property
+    def sourceInterpreter(self):
+        return self._python
+
+
     def create(self, site_packages=False):
         """
         Create the virtualenv. This uses "/usr/bin/env python2"'s virtualenv


### PR DESCRIPTION
Scope
====

This updates the Ubuntu version used by Vagrant VM to align with production

While working on this it can be a good time to also fix https://github.com/twisted-infra/braid/issues/40

Now that we have a modern Linux and Python version we can review the way system is bootstrapped.
Ex install virtualenv with pip (as we now have pip)


Changes
=======

Update base image.


How to test
=========

1.Distro check
-------------------

On an existing vagrant vm running 12.04 run `fab config.vagrant base.bootstrap`
it should fail with a message informing that 


2.Xenial update
---------------------

Destroy your existing vagrant vm, start a new one and run bootstrap on it.
Vagrant should get xenial and base should apply with success

A better test would be to check that a service is actually running... but I don't know which service is functional.
Checking that each service works on 16.04 will be done in a separate PR


```
$ vagrant destroy
$ vagrant up
$ fab config.vagrant base.bootstrap
```