### PR TITLE
Cleanup buildmaster after RAX removal.

### DIFF
--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -70,6 +70,7 @@ slave_max_builds = {
 
 fedora24_slaves = ['fedora-fedora24-%d' % (i,) for i in range(1,3)]
 fedora25_slaves = ['fedora-fedora25-%d' % (i,) for i in range(1,3)]
+rhel7_slaves = ['fedora-rhel7-%d' % (i,) for i in range(1,3)]
 
 
 allpy27_slaves = fedora24_slaves + fedora25_slaves
@@ -244,6 +245,28 @@ builders.append({
     'factory': TwistedToxCoverageBuildFactory(
         git_update, toxEnv="py35-alldeps-withcov-posix",
         buildID="fedora25py3.5"),
+    'category': 'supported'})
+
+
+#
+# RHEL 7
+#
+builders.append({
+    'name': 'rhel7-py2.7',
+    'builddir': 'rhel7-py2.7',
+    'slavenames': rhel7_slaves,
+    'factory': TwistedToxBuildFactory(
+        git_update, toxEnv="py27-alldeps-nocov-posix",
+        reactors=["select", "poll", "epoll"]),
+    'category': 'supported'})
+
+builders.append({
+    'name': 'rhel7-py2.7-coverage',
+    'builddir': 'rhel7-py2.7-coverage',
+    'slavenames': rhel7_slaves,
+    'factory': TwistedToxCoverageBuildFactory(
+        git_update, toxEnv="py27-alldeps-withcov-posix",
+        buildID='rhel7py2.7'),
     'category': 'supported'})
 
 

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -70,19 +70,9 @@ slave_max_builds = {
 
 fedora24_slaves = ['fedora-fedora24-%d' % (i,) for i in range(1,3)]
 fedora25_slaves = ['fedora-fedora25-%d' % (i,) for i in range(1,3)]
-rhel7_slaves = ['fedora-rhel7-%d' % (i,) for i in range(1,3)]
 
-freebsd10_slaves = ['rax-fbsd10-%d' % (i,) for i in range(1,3)]
-debian8_slaves = ['rax-debian8-%d' % (i,) for i in range(1,3)]
-debian9_slaves = ['rax-debian9-%d' % (i,) for i in range(1,3)]
-ubuntu16_04_slaves = ['rax-ubuntu1604-%d' % (i,) for i in range(1,4)]
 
-allpy27_slaves = fedora24_slaves + fedora25_slaves + ubuntu16_04_slaves + debian9_slaves
-
-# These builders run some heavy builders (pypy, jython) so only run one at a
-# time.
-for slave in ubuntu16_04_slaves + freebsd10_slaves:
-    slave_max_builds[slave] = 1
+allpy27_slaves = fedora24_slaves + fedora25_slaves
 
 
 c['slaves'] = []
@@ -118,39 +108,6 @@ builders.append({
     'factory': TwistedDocumentationBuildFactory(git_update),
     'category': 'supported'})
 
-
-#
-# Debian 8
-#
-builders.append({
-    'slavenames': debian8_slaves,
-    'name': 'debian8-py2.7',
-    'builddir': 'debian8-py2.7',
-    'factory': TwistedToxBuildFactory(
-        git_update, toxEnv="py27-tests",
-        reactors=["select", "poll", "epoll"]),
-    'category': 'supported'})
-
-#
-# Debian 9
-#
-builders.append({
-    'slavenames': debian9_slaves,
-    'name': 'debian9-py2.7',
-    'builddir': 'debian9-py2.7',
-    'factory': TwistedToxBuildFactory(
-        git_update, toxEnv="py27-alldeps-nocov-posix",
-        reactors=["select", "poll", "epoll"]),
-    'category': 'supported'})
-
-builders.append({
-    'name': 'debian9-py3.5',
-    'builddir': 'debian9-py3.5',
-    'slavenames': debian9_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update, toxEnv="py35-alldeps-nocov-posix",
-        reactors=["select", "poll", "epoll"]),
-    'category': 'supported'})
 
 #
 # Windows 7
@@ -207,204 +164,6 @@ builders.append({
         git_update, toxEnv="py27-alldeps-nocov-posix",
         reactors=["select", "poll", "epoll"]),
     'category': 'supported'})
-
-
-#
-# Ubuntu 16.04
-#
-builders.append({
-    'name': 'ubuntu16.04-py2.7',
-    'builddir': 'ubuntu16.04-py2.7',
-    'slavenames': ubuntu16_04_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update, toxEnv="py27-alldeps-nocov-posix",
-        reactors=["select", "poll", "epoll"]),
-    'category': 'supported'})
-
-#
-# No OPTIONAL modules
-#
-builders.append({
-    'name': 'ubuntu16.04-py2.7-nodeps',
-    'slavenames': ubuntu16_04_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update,
-        toxEnv='py27-nodeps-nocov-posix',
-        reactors=["select", "poll", "epoll"],
-        ),
-    'category': 'supported',
-    })
-
-builders.append({
-    'name': 'ubuntu16.04-py2.7-nodeps-coverage',
-    'slavenames': ubuntu16_04_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update,
-        toxEnv='py27-nodeps-withcov-posix,codecov-publish',
-        env={'CODECOV_TOKEN': private.codecov_twisted_token,
-             'CI_BUILD_ID': 'ubuntu16.04py2.7-nomodules'}
-        ),
-    'category': 'supported',
-    })
-
-builders.append({
-    'name': 'ubuntu16.04-py2.7-newstyle-coverage',
-    'builddir': 'ubuntu16.04-py2.7-newstyle-coverage',
-    'slavenames': ubuntu16_04_slaves,
-    'factory': TwistedToxCoverageBuildFactory(
-        git_update, toxEnv="py27-alldeps-withcov-posix",
-        buildID='ubuntu16.04py2.7newstyle',
-        env={"TWISTED_NEWSTYLE": "1"}
-    ),
-    'category': 'supported'})
-
-builders.append({
-    'name': 'ubuntu16.04-py2.7-coverage',
-    'builddir': 'ubuntu16.04-py2.7-coverage',
-    'slavenames': ubuntu16_04_slaves,
-    'factory': TwistedToxCoverageBuildFactory(
-        git_update, toxEnv="py27-alldeps-withcov-posix",
-        buildID='ubuntu16.04py2.7'
-    ),
-    'category': 'supported'})
-
-
-builders.append({
-    'name': 'ubuntu16.04-py3.5',
-    'builddir': 'ubuntu1604-python-3.5',
-    'slavenames': ubuntu16_04_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update, toxEnv="py35-alldeps-nocov-posix",
-        reactors=["select", "poll", "epoll"]),
-    'category': 'supported'})
-
-builders.append({
-    'name': 'ubuntu16.04-py3.5-asyncio-coverage',
-    'builddir': 'ubuntu1604-py3.5-asyncio-coverage',
-    'slavenames': ubuntu16_04_slaves,
-    'factory': TwistedToxCoverageBuildFactory(
-        git_update, toxEnv="py35-alldeps-withcov-posix",
-        buildID="ubuntu1604aiopy3.5", reactors=["asyncio"]),
-    'category': 'supported'})
-
-builders.append({
-    'name': 'ubuntu16.04-py3.5-coverage',
-    'builddir': 'ubuntu1604-py3.5-coverage',
-    'slavenames': ubuntu16_04_slaves,
-    'factory': TwistedToxCoverageBuildFactory(
-        git_update, toxEnv="py35-alldeps-withcov-posix",
-        buildID="ubuntu1604py3.5"),
-    'category': 'supported'})
-
-builders.append({
-    'name': 'ubuntu16.04-pypy5',
-    'builddir': 'ubuntu16.04-pypy5',
-    'slavenames': ubuntu16_04_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update, toxEnv="pypy-alldeps-nocov-posix",
-        reactors=["select", "poll", "epoll"]),
-    'category': 'unsupported'})
-
-builders.append({
-    'name': 'ubuntu16.04-py3.6',
-    'builddir': 'ubuntu1604-python-3.6',
-    'slavenames': ["rax-ubuntu1604-1"],
-    'factory': TwistedToxBuildFactory(
-        git_update, toxEnv="py36-alldeps-nocov-posix",
-        reactors=["select", "poll", "epoll", "asyncio"]),
-    'category': 'supported'})
-
-builders.append({
-    'name': 'ubuntu16.04-py3.6-coverage',
-    'builddir': 'ubuntu1604-py3.6-coverage',
-    'slavenames': ["rax-ubuntu1604-1"],
-    'factory': TwistedToxCoverageBuildFactory(
-        git_update, toxEnv="py36-alldeps-withcov-posix",
-        buildID="ubuntu1604py3.6"),
-    'category': 'supported'})
-
-#
-# Benchmarks
-#
-builders.append({
-    'name': 'ubuntu16.04-py2.7-benchmark',
-    'builddir': 'ubuntu16.04-py2.7-benchmark',
-    'slavenames': ['rax-ubuntu1604-2'],
-    'locks': [twoCPULock.access('counting')],
-    'factory': TwistedBenchmarksFactory(python='python',
-                                        source=git_update),
-    'category': 'benchmark'})
-
-builders.append({
-    'name': 'ubuntu16.04-pypy5-benchmark',
-    'builddir': 'ubuntu16.04-pypy5-benchmark',
-    'slavenames': ['rax-ubuntu1604-2'],
-    'locks': [twoCPULock.access('counting')],
-    'factory': TwistedBenchmarksFactory(python="pypy",
-                                        source=git_update),
-        'category': 'benchmark'})
-
-builders.append({
-    'name': 'ubuntu16.04-py3.5-benchmark',
-    'builddir': 'ubuntu16.04-py3.5-benchmark',
-    'slavenames': ['rax-ubuntu1604-2'],
-    'locks': [twoCPULock.access('counting')],
-    'factory': TwistedBenchmarksFactory(python="python3.5",
-                                        source=git_update),
-    'category': 'benchmark'})
-
-#
-# FreeBSD 10
-#
-
-builders.append({
-    'name': 'freebsd10-py2.7',
-    'slavenames': freebsd10_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update,
-        toxEnv='py27-alldeps-nocov-posix',
-        env={"CC": "gcc"}
-        ),
-    'category': 'supported',
-})
-
-builders.append({
-    'name': 'freebsd10-py2.7-coverage',
-    'slavenames': freebsd10_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update,
-        toxEnv='py27-alldeps-withcov-posix,codecov-publish',
-        env={'CODECOV_TOKEN': private.codecov_twisted_token,
-             'CI_BUILD_ID': 'freebsd10py2.7',
-             "CC": "gcc"}
-        ),
-    'category': 'supported',
-})
-
-builders.append({
-    'name': 'freebsd10-py3.5',
-    'slavenames': freebsd10_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update,
-        toxEnv='py35-alldeps-nocov-posix',
-        env={"CC": "gcc"}
-        ),
-    'category': 'supported',
-})
-
-builders.append({
-    'name': 'freebsd10-py3.5-coverage',
-    'slavenames': freebsd10_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update,
-        toxEnv='py35-alldeps-withcov-posix,codecov-publish',
-        env={'CODECOV_TOKEN': private.codecov_twisted_token,
-             'CI_BUILD_ID': 'freebsd10py3.5',
-             "CC": "gcc"}
-        ),
-    'category': 'supported',
-})
-
 
 
 #
@@ -485,28 +244,6 @@ builders.append({
     'factory': TwistedToxCoverageBuildFactory(
         git_update, toxEnv="py35-alldeps-withcov-posix",
         buildID="fedora25py3.5"),
-    'category': 'supported'})
-
-
-#
-# RHEL 7
-#
-builders.append({
-    'name': 'rhel7-py2.7',
-    'builddir': 'rhel7-py2.7',
-    'slavenames': rhel7_slaves,
-    'factory': TwistedToxBuildFactory(
-        git_update, toxEnv="py27-alldeps-nocov-posix",
-        reactors=["select", "poll", "epoll"]),
-    'category': 'supported'})
-
-builders.append({
-    'name': 'rhel7-py2.7-coverage',
-    'builddir': 'rhel7-py2.7-coverage',
-    'slavenames': rhel7_slaves,
-    'factory': TwistedToxCoverageBuildFactory(
-        git_update, toxEnv="py27-alldeps-withcov-posix",
-        buildID='rhel7py2.7'),
     'category': 'supported'})
 
 

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -15,26 +15,10 @@ slaves = [
 
     "bot-glyph-1",
     "bot-glyph-6",
-    "tavendo-freebsd-10.1-amd64",
 
-    "fedora-fedora22-1",
-    "fedora-fedora22-2",
-    "fedora-fedora23-1",
-    "fedora-fedora23-2",
     "fedora-fedora24-1",
     "fedora-fedora24-2",
-    "fedora-rhel7-1",
-    "fedora-rhel7-2",
-
-    "osuosl-osx10.6",
-
-    "rax-ubuntu1204-1",
-    "rax-ubuntu1204-2",
-    "rax-ubuntu1604-1",
-    "rax-ubuntu1604-2",
-    "rax-ubuntu1604-3",
-    "rax-debian8-1",
-    "rax-debian8-2",
+    "fedora-fedora25-1",
 
     "github",
 ]

--- a/services/buildbot/master/private.py.sample
+++ b/services/buildbot/master/private.py.sample
@@ -19,7 +19,8 @@ slaves = [
     "fedora-fedora24-1",
     "fedora-fedora24-2",
     "fedora-fedora25-1",
-
+    "fedora-rhel7-1",
+    "fedora-rhel7-2",
     "github",
 ]
 


### PR DESCRIPTION
Scope
====

This removes the builders which were assigned to the RAX slaves which were removes.


Changes
=======

Just remove everything that was offline, with the exception of OSX 10.06 and RHEL-7

Removed the slaves from twisted-infra-secret repo.

As a drive by, I have removed the `github` slaves, as I don't think that is doing anything useful :)

I tried to update the README files to better document what is going on here.

How to test
==========

The changes were already applied on PROD

See https://buildbot.twistedmatrix.com/buildslaves
There osx-10.06 without builder... and the RHEL-7 which @hawkowl will get back online soon.

I was not able to push the changes to twisted-infra-secret as the public key for @markrwilliams is expired.

Make sure twisted-info-secret is up to date and revealed :)

```
$ fab config.production buildbot.reconfigure
```