### PR TITLE
Switch macOS builder to pyenv

### DIFF
--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -478,16 +478,6 @@ builders.append({
 #
 # OS X 10.10
 #
-builders.append({
-    'slavenames': ['egh-osx-1'],
-    'locks': [twoCPULock.access('counting')],
-    'name': 'osx10.10-py2.7',
-    'builddir': 'osx10.10-py2.7',
-    'factory': TwistedToxBuildFactory(
-        git_update, toxEnv="py27-alldeps-nocov-posix",
-        reactors=["select"]),
-    'category': 'supported'})
-
 
 builders.append({
     'slavenames': ['egh-osx-1'],

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -476,14 +476,19 @@ builders.append({
 
 
 #
-# OS X 10.10
+# OS X 10.11
 #
+# Assumes pyenv global 2.7.14 3.6.5 3.5.3
+_MACOS_PATH = (
+    "/Users/buildbot/.pyenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+)
 
 builders.append({
     'slavenames': ['egh-osx-1'],
     'locks': [twoCPULock.access('counting')],
-    'name': 'osx10.10-py2.7-coverage',
-    'builddir': 'osx10.10-py2.7-coverage',
+    'name': 'osx10.11-py2.7-coverage',
+    'builddir': 'osx10.11-py2.7-coverage',
+    'env': {'PATH': _MACOS_PATH},
     'factory': TwistedToxCoverageBuildFactory(
         git_update, toxEnv="py27-alldeps-withcov-posix",
         buildID='osx1010py2.7'),
@@ -493,8 +498,9 @@ builders.append({
 builders.append({
     'slavenames': ['egh-osx-1'],
     'locks': [twoCPULock.access('counting')],
-    'name': 'osx10.10-py2.7-kqueue',
-    'builddir': 'osx10.10-py2.7-kqueue',
+    'name': 'osx10.11-py2.7-kqueue',
+    'builddir': 'osx10.11-py2.7-kqueue',
+    'env': {'PATH': _MACOS_PATH},
     'factory': TwistedToxBuildFactory(
         git_update, toxEnv="py27-alldeps-nocov-posix",
         reactors=["kqueue"]),

--- a/services/buildbot/master/master.cfg
+++ b/services/buildbot/master/master.cfg
@@ -478,7 +478,10 @@ builders.append({
 #
 # OS X 10.11
 #
-# Assumes pyenv global 2.7.14 3.6.5 3.5.3
+# Assumptions:
+# 1. Python 2.7 is pyenv's python (pyenv global 2.7.14)
+# 2. python -m virtualenv works (python -m pip install --user virtualenv)
+
 _MACOS_PATH = (
     "/Users/buildbot/.pyenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 )


### PR DESCRIPTION
@mithrandi pointed out that incremental fails to install because setuptools downloads requirements in a distribution's `setup_requires`, not `pip`.  That means we need a Python installation whose (`urllib.request`|`urllib2`)`.urlopen` can speak TLS 1.2 to PyPI.org.

I've installed Python 2.7.14, 3.5.3, and 3.6.5 under the buildbot user via `pyenv`; `pyenv` evidently downloads OpenSSL 1.0.2 and links `_ssl` against it on older macOS releases:

https://github.com/pyenv/pyenv/blob/b960f863ccf81e1311706b0976fde78e58141704/plugins/python-build/share/python-build/3.6.5#L2
https://github.com/pyenv/pyenv/blob/b960f863ccf81e1311706b0976fde78e58141704/plugins/python-build/bin/python-build#L1479-L1484

I did not use brew because other things have been installed in /usr/local/bin, and I want everything I'm doing to be reversible.