### PR TITLE
add readthedocs CNAME

### DIFF
--- a/services/t-names/zones/twistedmatrix.com
+++ b/services/t-names/zones/twistedmatrix.com
@@ -62,6 +62,7 @@ zone = [
         "29GE4xiMbXfwIDAQAB"),
 
     CNAME('planet.twistedmatrix.com', planet, ttl='1D'),
+    CNAME('docs.twistedmatrix.com', 'readthedocs.io', ttl='1D'),
     CNAME('glyph.twistedmatrix.com', 'writing.glyph.im', ttl='1D'),
     CNAME('secret.glyph.twistedmatrix.com', googleHosting, ttl='1D'),
     CNAME('labs.twistedmatrix.com', googleHosting, ttl='1D'),


### PR DESCRIPTION
This adds a docs.twistedmatrix.com which will redirect to the Read the docs service.

The plan is to use docs.twistedmatrix.com as the canonical domain for hosting the docs.

There will be a second PR to redirect https://twistedmatrix.com/documents/current/ to the new domain, but first we should have this pushed to PROD and make sure it works and later we can push the redirection.