### PR TITLE
Hacky twistedweb.com cert renewal

### DIFF
--- a/services/t-web/README.certbot
+++ b/services/t-web/README.certbot
@@ -1,0 +1,55 @@
+Certbot was installed as a snap per https://certbot.eff.org/lets-encrypt/ubuntufocal-other
+This includes the weird symlink in step 6.
+
+There is now a systemd service to run t-web at /etc/systemd/system/t-web.service
+
+To start it:
+
+  systemctl restart t-web
+
+The config/twisted-web/twisted-web script has been modified to serve:
+
+  /srv/t-web/certbot-webroot/.well-known/acme-challenge
+
+at
+
+  http://twistedmatrix.com/.well-known/acme-challenge
+
+Certbot was set up to run in webroot mode (see the transcript below).
+
+There is a hook to restart t-web on cert renewal at /etc/letsencrypt/renewal-hooks/post/t-web.sh
+
+—twm
+March 591th, 2020 
+
+==============================================================================================
+
+Certbot transcript:
+
+$ sudo certbot certonly --webroot
+Saving debug log to /var/log/letsencrypt/letsencrypt.log
+Please enter the domain name(s) you would like on your certificate (comma and/or
+space separated) (Enter 'c' to cancel): twistedmatrix.com www.twistedmatrix.com
+Requesting a certificate for twistedmatrix.com and www.twistedmatrix.com
+Input the webroot for twistedmatrix.com: (Enter 'c' to cancel): /srv/t-web/certbot-webroot
+
+Select the webroot for www.twistedmatrix.com:
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+1: Enter a new webroot
+2: /srv/t-web/certbot-webroot
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Select the appropriate number [1-2] then [enter] (press 'c' to cancel): 2
+
+Successfully received certificate.
+Certificate is saved at: /etc/letsencrypt/live/twistedmatrix.com/fullchain.pem
+Key is saved at:         /etc/letsencrypt/live/twistedmatrix.com/privkey.pem
+This certificate expires on 2022-01-10.
+These files will be updated when the certificate renews.
+Certbot has set up a scheduled task to automatically renew this certificate in the background.
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+If you like Certbot, please consider supporting our work by:
+ * Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
+ * Donating to EFF:                    https://eff.org/donate-le
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+

--- a/services/t-web/fabfile.py
+++ b/services/t-web/fabfile.py
@@ -9,7 +9,7 @@ from fabric.api import run, settings, env, put, sudo, local
 from os import path
 from twisted.python.util import sibpath
 
-from braid import authbind, cron, archive
+from braid import authbind, archive
 from braid.twisted import service
 from braid.debian import equivs
 from braid.tasks import addTasks
@@ -41,7 +41,7 @@ class TwistedWeb(service.Service):
             run('/bin/ln -nsf {}/start {}/start'.format(self.configDir, self.binDir))
             run('/bin/ln -nsf {}/start-maintenance {}/start-maintenance'.format(self.configDir, self.binDir))
             self.update()
-            cron.install(self.serviceUser, '{}/crontab'.format(self.configDir))
+            # cron.install(self.serviceUser, '{}/crontab'.format(self.configDir))
 
             run('/bin/mkdir -p ~/data')
             if env.get('installPrivateData'):

--- a/services/t-web/t-web.service
+++ b/services/t-web/t-web.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Twisted Web
+After=network.target
+
+[Service]
+Environment=WEBSITE_ROOT=/srv/t-web/config
+Environment=WEBSITE_NAME=twisted-web
+LimitNOFILE=4096
+User=t-web
+Type=forking
+ExecStart=/usr/bin/authbind -- ${HOME}/virtualenv/bin/twistd --reactor poll --pidfile ${HOME}/run/twistd.pid --rundir ${HOME}/run/ --python=${WEBSITE_ROOT}/twisted-web/twisted-web --logfile=${HOME}/log/twistd.log --no_save
+PIDFile=/srv/t-web/run/twistd.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/services/t-web/t-web.sh
+++ b/services/t-web/t-web.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# certbot renewal hook. Put this in /etc/letsencrypt/renewal-hooks/post
+exec systemctl restart t-web.service

--- a/services/t-web/twisted-web/twisted-web
+++ b/services/t-web/twisted-web/twisted-web
@@ -22,7 +22,6 @@ from txacme.client import Client
 from txacme.endpoint import load_or_create_client_key
 from txacme.service import AcmeIssuingService
 from txacme.store import DirectoryStore
-from txacme.urls import LETSENCRYPT_DIRECTORY
 
 
 def movedTo(request, url):
@@ -215,9 +214,9 @@ top = rewrite.RewriterResource(root, rewrite.tildeToUsers, rewrite.alias("highsc
 
 # Generate the Site factory. You will not normally
 # want to modify this line.
-# responder = HTTP01Responder()
-responder = static.File("/srv/t-web/acme-challenge")
-site = server.Site(EnsureHTTPS(top, responder.resource), logPath=logPath)
+responder = HTTP01Responder()
+# site = server.Site(EnsureHTTPS(top, responder.resource), logPath=logPath)
+site = server.Site(EnsureHTTPS(top, static.File("/srv/t-web/certbot-webroot/.well-known/acme-challenge")), logPath=logPath)
 
 # Generate the Application. You will not normally
 # want to modify this line.
@@ -248,19 +247,27 @@ httpsService = StreamServerEndpointService(
 httpsService.setServiceParent(application)
 
 if websiteRoot.child('production').exists():
-    issuingService = AcmeIssuingService(
-        cert_store=DirectoryStore(certificates),
-        client_creator=(lambda: Client.from_url(
-            reactor=reactor,
-            url=LETSENCRYPT_DIRECTORY,
-            key=load_or_create_client_key(certificates),
-            alg=RS256,
-        )),
-        clock=reactor,
-        responders=[responder],
+
+    d = Client.from_url(
+        reactor=reactor,
+        url=URL.fromText(
+            u'https://acme-v02.api.letsencrypt.org/directory'),
+        key=load_or_create_client_key(certificates),
+        alg=RS256,
     )
 
-    issuingService.setServiceParent(application)
+    def cb_got_client(client):
+        issuingService = AcmeIssuingService(
+            cert_store=DirectoryStore(certificates),
+            client=client,
+            clock=reactor,
+            responders=[responder],
+        )
+        issuingService.start()
+
+        issuingService.setServiceParent(application)
+
+    d.addCallback(cb_got_client)
 
 # If you do not want to modify this file directly, most modifications
 # can be done via putting a Python file in /etc/twisted-web/local.d

--- a/services/t-web/twisted-web/twisted-web
+++ b/services/t-web/twisted-web/twisted-web
@@ -215,7 +215,8 @@ top = rewrite.RewriterResource(root, rewrite.tildeToUsers, rewrite.alias("highsc
 
 # Generate the Site factory. You will not normally
 # want to modify this line.
-responder = HTTP01Responder()
+# responder = HTTP01Responder()
+responder = static.File("/srv/t-web/acme-challenge")
 site = server.Site(EnsureHTTPS(top, responder.resource), logPath=logPath)
 
 # Generate the Application. You will not normally


### PR DESCRIPTION
Per discussion on IRC, I hacked up t-web on the Azure VM to use certbot for certificate renewal. This required modifications to the ``twisted-web`` application so that it would serve ``http://twistedmatrix.com/.well-known/acme-challenge`` because txacme was wired to own that hierarchy. With that done I could follow the [certbot webroot instructions](https://certbot.eff.org/lets-encrypt/ubuntufocal-other). I copied the full script as deployed into this PR because there appear to have been other changes made to it.

I was a bit confused about the service was started and supervised (well, not supervised it seems?). I ended up replacing the init script run from cron with a systemd service, so here are the artifacts I generated as part of that. I didn't really attempt to update Braid properly.

I am not sure how long any of this will live, but I thought this PR might serve as documentation of what I've done.

/cc @glyph, @adiroiban
